### PR TITLE
Update guidance to prefer nextest for Rust testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ Do this autonomously. Do not defer it to “later docs cleanup”.
 
 This repository contains the Ousia compiler workspace (`crates/*`) plus editor tooling under `tools/vscode-ousia/`. Prefer touching compiler code only unless explicitly requested.
 
+## Testing Runner Preference
+
+- For Rust test execution, use `cargo nextest run` when `cargo-nextest` is available in the environment (it is the preferred default because it is faster).
+- Fall back to `cargo test` only when `cargo-nextest` is unavailable or when parity with CI behavior must be verified explicitly.
+
 ## Current Syntax Notes
 
 - Templates use square brackets for type parameters and instantiation arguments: `template Option[T] { ... }`, `instantiate OptionI32 = Option[I32]`.

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -17,10 +17,25 @@ From repository root:
 
 ```bash
 cargo check --all-targets --all-features
+# Prefer nextest when available (faster local execution).
+cargo nextest run --all-targets --all-features
+```
+
+Fallback when `cargo-nextest` is not installed:
+
+```bash
 cargo test --all-targets --all-features
 ```
 
 Targeted crate:
+
+```bash
+# Prefer nextest when available.
+cargo nextest run -p oac
+cargo nextest run -p qbe-smt
+```
+
+Fallback when `cargo-nextest` is not installed:
 
 ```bash
 cargo test -p oac
@@ -129,7 +144,7 @@ Missing tools can cause test/build failures unrelated to Rust logic.
 2. Inspect generated intermediates (`tokens.json`, `ast.json`, `ir.json`, `ir.qbe`) and checker artifacts (`target/oac/prove/site_*.qbe`, `site_*.smt2`, `target/oac/struct_invariants/site_*.qbe`, `site_*.smt2`) when applicable. Checker `.qbe` artifacts are rendered from in-memory `qbe::Function` obligations.
 3. Isolate stage failure: tokenize, parse, resolve, codegen, or external tool invocation.
 4. Add/adjust snapshot to encode fixed behavior.
-5. Run full test suite.
+5. Run full test suite (prefer `cargo nextest run`; use `cargo test` fallback only if nextest is unavailable).
 
 ## Autonomous Sync Rule
 

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -48,7 +48,8 @@ Act like a compiler engineer, not a text editor:
 ## Pre-Commit Checklist
 
 - `cargo check --all-targets --all-features`
-- `cargo test --all-targets --all-features`
+- `cargo nextest run --all-targets --all-features` (preferred when `cargo-nextest` is available)
+- `cargo test --all-targets --all-features` (fallback when `cargo-nextest` is unavailable)
 - Review snapshot diffs for unintended behavior changes.
 - Update docs in `agents/` and root `AGENTS.md` if any context changed.
 


### PR DESCRIPTION
## Summary
- document that agents must run `cargo nextest run` when available and fall back to `cargo test` otherwise
- add matching instructions to AGENTS.md, testing guide, and engineering playbook to keep policy synced

## Testing
- Not run (not requested)