### PR TITLE
Document and wire namespaced Clib externs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 
 - Templates use square brackets for type parameters and instantiation arguments: `template Option[T] { ... }`, `instantiate OptionI32 = Option[I32]`.
 - Top-level imports are flat and same-directory only: `import "helpers.oa"`. Imported declarations are merged into one global scope.
-- Namespaces are top-level and declaration-only: `namespace TypeName { fun helper(...) -> ... { ... } }`. Namespace functions are called via `TypeName.helper(...)` and are lowered to internal function names using `TypeName__helper`.
-- External declarations use `extern fun name(args...) -> Type` (no body). In v1, `extern fun` is top-level only.
+- Namespaces are top-level and declaration-only: `namespace TypeName { fun helper(...) -> ... { ... } }` and `namespace TypeName { extern fun symbol(...) -> ... }`. Namespace calls use `TypeName.helper(...)` syntax and lower to internal lookup names using `TypeName__helper`.
+- External declarations use `extern fun name(args...) -> Type` (no body). In v1 they may appear at top level and inside `namespace` blocks (no bodies, no `comptime`).
 - Struct field lists allow optional trailing commas in both type declarations and struct literals.
 - The stdlib entrypoint `crates/oac/src/std.oa` is now an import aggregator over split files (`std_ascii.oa`, `std_char.oa`, `std_null.oa`, `std_string.oa`, `std_collections.oa`, `std_json.oa`, `std_clib.oa`).
 - The split stdlib now exposes namespaced helper APIs where applicable: JSON parsing helpers are called via `Json.*` (for example `Json.json_kind`, `Json.parse_json_document_result`).
@@ -41,7 +41,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - The stdlib also exposes `Char` as an `I32` wrapper (`struct Char { code: I32 }`) with namespaced helpers (`Char.from_code`, `Char.code`, `Char.equals`).
 - The stdlib now also exposes `Null` as an empty struct (`struct Null {}`) with namespaced constructor helper `Null.value()`.
 - The stdlib now also defines `Bytes` (`struct Bytes { ptr: PtrInt, len: I32 }`) and `String` as a tagged enum (`Literal(Bytes)` / `Heap(Bytes)`) in `std_string.oa`; `String` is no longer a compiler-primitive type.
-- C interop signatures are std-owned `extern fun` declarations in `std_clib.oa` (the compiler no longer injects a hardcoded libc JSON signature table).
+- C interop in std is exposed through namespaced calls (`Clib.*`) and declared in `std_clib.oa` as `namespace Clib { extern fun ... }`; resolver keeps namespaced internal keys (`Clib__name`) while codegen emits declared extern symbol names for linking (for example `malloc`).
 - Built-in `Void` is available for C-style procedure signatures; in v1 only `extern fun` may return `Void`, and `Void` is rejected as a parameter type.
 - Built-in `U8` is available as an unsigned byte-like numeric type (`U8/U8` arithmetic and comparisons are allowed with no implicit coercions).
 - The resolver also exposes `PtrInt` as a standard numeric alias hardcoded to `I64` (for pointer-sized integer use sites).

--- a/agents/01-repo-map.md
+++ b/agents/01-repo-map.md
@@ -36,7 +36,7 @@ Editor tooling in this repository:
 - `crates/oac/src/std.oa`: stdlib import entrypoint injected during resolution.
 - `crates/oac/src/std_*.oa`: split stdlib modules imported by `std.oa`.
 - `crates/oac/src/std_string.oa`: std-owned `Bytes` + `String` representation (`String` enum with literal/heap variants).
-- `crates/oac/src/std_clib.oa`: std-owned C interop declarations via `extern fun` (replaces compiler hardcoded libc signature JSON).
+- `crates/oac/src/std_clib.oa`: std-owned C interop declarations for `Clib.*` namespaced API via `namespace Clib { extern fun ... }` (resolver keys remain `Clib__*`; replaces compiler hardcoded libc signature JSON).
 - `crates/oac/execution_tests/*.oa`: language behavior fixtures (positive + negative).
 - `crates/oac/src/snapshots/*.snap`: canonical snapshots for tests.
 - `.github/workflows/ci.yml`: CI checks (`cargo check`, `cargo test`).

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -50,7 +50,7 @@ Key tests:
 - `crates/oac/src/parser.rs` tests assert template bracket syntax parsing, legacy `()` rejection, struct-invariant declaration syntax (`invariant ... for (...)`, with optional identifier, including inside templates), and optional trailing commas for struct declarations/literals.
 - `crates/oac/src/parser.rs` also includes top-level test declaration parsing coverage (`test "..." { ... }`).
 - `crates/oac/src/parser.rs` tests also cover namespace declaration parsing and namespaced call syntax (`TypeName.helper(...)`).
-- `crates/oac/src/parser.rs` also covers top-level `extern fun` declaration parsing (signature-only, `is_extern` metadata).
+- `crates/oac/src/parser.rs` also covers top-level `extern fun` parsing plus namespace-scoped extern parsing (`namespace Name { extern fun ... }`) including internal-name mangling and preserved extern symbol names.
 - `crates/oac/src/parser.rs` includes an AST snapshot regression (`parser_float_literals_ast`) for mixed FP32/FP64 literal parsing.
 - `crates/oac/src/parser.rs` also includes a regression for FP32 literal parsing (`Literal::Float32`).
 - `crates/oac/src/parser.rs` also includes a regression for FP64 literal parsing (`Literal::Float64` from `f64` suffix).
@@ -58,7 +58,7 @@ Key tests:
 - `crates/oac/src/flat_imports.rs` tests assert flat import resolution: merge behavior, same-directory path constraints, and cycle detection.
 - `crates/oac/src/flat_imports.rs` merge coverage also includes imported test declaration propagation.
 - `crates/oac/src/ir.rs` includes a regression test that stdlib split files are loaded through `std.oa` imports.
-- That regression currently asserts representative split-stdlib symbols including JSON (`Json__parse_json_document`), ASCII helpers (`AsciiChar`, `AsciiChar__from_code`), char/null/string helpers (`Char__from_code`, `Null__value`, `String__from_literal_parts`, `String__from_heap_parts`), C externs (`malloc`, `free`), and standard aliases/types (`PtrInt`, `U8`, `Void`, `Bytes`, std-defined `String` enum).
+- That regression currently asserts representative split-stdlib symbols including JSON (`Json__parse_json_document`), ASCII helpers (`AsciiChar`, `AsciiChar__from_code`), char/null/string helpers (`Char__from_code`, `Null__value`, `String__from_literal_parts`, `String__from_heap_parts`), C externs (`Clib__malloc`, `Clib__free`), and standard aliases/types (`PtrInt`, `U8`, `Void`, `Bytes`, std-defined `String` enum).
 - The same regression also asserts stdlib `AsciiChar` invariant registration/synthesis (`struct_invariants["AsciiChar"]` and `__struct__AsciiChar__invariant` function definition).
 - `crates/oac/src/ir.rs` also validates accepted `main` signatures (`main()`, `main(argc: I32, argv: I64)`, and `main(argc: I32, argv: PtrInt)`).
 - `crates/oac/src/ir.rs` includes alias coverage for `PtrInt` behaving as `I64` in function calls/equality and type-definition mapping.

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -39,7 +39,7 @@ Act like a compiler engineer, not a text editor:
 
 ### Backend/runtime behavior change
 - Inspect generated QBE text and runtime output snapshots.
-- Check interop assumptions with std-declared `extern fun` bindings (`std_clib.oa`) and helper functions.
+- Check interop assumptions with std `Clib.*` bindings in `std_clib.oa` (`namespace`-scoped `extern fun` declarations that resolve to `Clib__*` internal keys while preserving declared link symbols) and helper functions.
 
 ### Interop/bindings behavior change
 - Prefer stdlib declarations (`extern fun`) over compiler hardcoded signature tables.

--- a/crates/oac/src/std_clib.oa
+++ b/crates/oac/src/std_clib.oa
@@ -1,18 +1,20 @@
-extern fun malloc(size: PtrInt) -> PtrInt
-extern fun free(ptr: PtrInt) -> Void
-extern fun calloc(nmemb: PtrInt, size: PtrInt) -> PtrInt
-extern fun realloc(ptr: PtrInt, size: PtrInt) -> PtrInt
-extern fun memcpy(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
-extern fun memset(s: PtrInt, c: Int, n: PtrInt) -> PtrInt
-extern fun memmove(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
-extern fun strlen(s: PtrInt) -> PtrInt
-extern fun strcmp(s1: PtrInt, s2: PtrInt) -> Int
-extern fun strcpy(dest: PtrInt, src: PtrInt) -> PtrInt
-extern fun strncpy(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
+namespace Clib {
+	extern fun malloc(size: PtrInt) -> PtrInt
+	extern fun free(ptr: PtrInt) -> Void
+	extern fun calloc(nmemb: PtrInt, size: PtrInt) -> PtrInt
+	extern fun realloc(ptr: PtrInt, size: PtrInt) -> PtrInt
+	extern fun memcpy(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
+	extern fun memset(s: PtrInt, c: Int, n: PtrInt) -> PtrInt
+	extern fun memmove(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
+	extern fun strlen(s: PtrInt) -> PtrInt
+	extern fun strcmp(s1: PtrInt, s2: PtrInt) -> Int
+	extern fun strcpy(dest: PtrInt, src: PtrInt) -> PtrInt
+	extern fun strncpy(dest: PtrInt, src: PtrInt, n: PtrInt) -> PtrInt
 
-extern fun open(pathname: PtrInt, flags: Int, mode: PtrInt) -> Int
-extern fun read(fd: Int, buf: PtrInt, count: PtrInt) -> PtrInt
-extern fun write(fd: Int, buf: PtrInt, count: PtrInt) -> PtrInt
-extern fun close(fd: Int) -> Int
+	extern fun open(pathname: PtrInt, flags: Int, mode: PtrInt) -> Int
+	extern fun read(fd: Int, buf: PtrInt, count: PtrInt) -> PtrInt
+	extern fun write(fd: Int, buf: PtrInt, count: PtrInt) -> PtrInt
+	extern fun close(fd: Int) -> Int
 
-extern fun exit(code: Int) -> Void
+	extern fun exit(code: Int) -> Void
+}

--- a/crates/oac/src/test_framework.rs
+++ b/crates/oac/src/test_framework.rs
@@ -48,6 +48,7 @@ pub fn lower_tests_to_program(mut ast: Ast) -> anyhow::Result<LoweredTestProgram
 
         ast.top_level_functions.push(Function {
             name: function_name,
+            extern_symbol_name: None,
             parameters: vec![],
             body,
             return_type: "I32".to_string(),
@@ -80,6 +81,7 @@ pub fn lower_tests_to_program(mut ast: Ast) -> anyhow::Result<LoweredTestProgram
 
     ast.top_level_functions.push(Function {
         name: "main".to_string(),
+        extern_symbol_name: None,
         parameters: vec![],
         body: main_body,
         return_type: "I32".to_string(),


### PR DESCRIPTION
- clarify namespace and extern support across AGENTS guidance files to reflect that `namespace` blocks allow `extern fun` and preserve mangled lookup keys while emitting declared symbols
- extend parser/IR to track namespace-scoped extern symbol metadata, expose it in function signatures, and resolve Clib externs through the new machinery
- teach QBE backend to call the declared symbol name instead of the mangled lookup key so `Clib.free`/`Clib.malloc` link correctly

**Testing**
- Not run (not requested)