### PR TITLE
Encourage breaking APIs in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Do this autonomously. Do not defer it to “later docs cleanup”.
 
 This repository contains the Ousia compiler workspace (`crates/*`) plus editor tooling under `tools/vscode-ousia/`. Prefer touching compiler code only unless explicitly requested.
 
+## API Stability Policy (Pre-Release)
+
+- Ousia is pre-release; source compatibility and stdlib API stability are not guaranteed yet.
+- Prefer semantic clarity, correctness, and maintainability over preserving legacy interfaces.
+- If a clean fix requires an API break (language surface, stdlib helpers, CLI behavior, or internal crate APIs), take the break instead of adding compatibility shims.
+- When introducing a breaking change, update tests/snapshots and all affected `agents/*` documentation in the same change set.
+
 ## Testing Runner Preference
 
 - For Rust test execution, use `cargo nextest run` when `cargo-nextest` is available in the environment (it is the preferred default because it is faster).

--- a/agents/03-language-semantics.md
+++ b/agents/03-language-semantics.md
@@ -2,6 +2,8 @@
 
 This describes behavior implemented in current compiler code, not aspirational docs.
 
+Pre-release policy: this compiler and stdlib are intentionally allowed to evolve with breaking API changes when needed for correctness or language design clarity.
+
 ## Built-In Types
 
 From `crates/oac/src/builtins.rs`:

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -6,6 +6,7 @@ Act like a compiler engineer, not a text editor:
 - preserve language invariants
 - protect existing behavior with tests
 - make changes stage-aware (tokenizer -> parser -> IR -> backend)
+- treat backward compatibility as secondary while Ousia is pre-release
 
 ## Working Model
 
@@ -18,10 +19,18 @@ Act like a compiler engineer, not a text editor:
 ## Practical Rules
 
 - Prefer small semantic deltas over broad rewrites.
+- Prefer coherent, cleaner APIs over compatibility shims when the two conflict.
 - Do not change parser shape without corresponding IR/type-check updates.
 - Do not change IR assumptions without auditing backend lowering paths.
 - Preserve or explicitly migrate snapshot expectations.
 - Keep error messages actionable and stable where possible.
+
+## Pre-Release Compatibility Posture
+
+- Ousia is pre-release; breaking API and language-surface changes are acceptable when they simplify or correct the design.
+- Do not keep obsolete interfaces solely for compatibility. Remove or reshape them when needed.
+- Ship breaks as complete migrations: update parser/IR/backend behavior, fixtures, snapshots, and `agents/*` docs together.
+- Make breakage explicit in change descriptions so downstream users can adjust quickly.
 
 ## Change Patterns
 


### PR DESCRIPTION
Summary
- clarify the repository API stability guidance in `AGENTS.md` and agent docs to remind contributors that pre-release changes may break APIs
- sprinkle the policy reminder across the language semantics and engineering playbook docs so the expectation stays visible near technical decisions

Testing
- Not run (not requested)