### PR TITLE
Expand LinkedList helpers and coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - Struct field lists allow optional trailing commas in both type declarations and struct literals.
 - The stdlib entrypoint `crates/oac/src/std.oa` is now an import aggregator over split files (`std_ascii.oa`, `std_char.oa`, `std_null.oa`, `std_string.oa`, `std_collections.oa`, `std_json.oa`, `std_clib.oa`).
 - The split stdlib now exposes namespaced helper APIs where applicable: JSON parsing helpers are called via `Json.*` (for example `Json.json_kind`, `Json.parse_json_document_result`).
+- The split stdlib collections now expose a richer persistent `LinkedList` template API: cached length via `len`/`length` (O(1) from node metadata), constructors/helpers (`empty`, `singleton`, `cons`, `push_front`), accessors (`front`, `tail`, `pop_front`, `at`, `at_or`), transforms (`append`, `reverse`, `take`, `drop`), and compatibility wrappers (`head_or`, `tail_or`, `length`).
 - The stdlib also exposes `AsciiChar` and `AsciiCharResult` with namespaced helpers (`AsciiChar.from_code`, `AsciiChar.from_string_at`, `AsciiChar.code`, `AsciiChar.is_digit`, `AsciiChar.is_whitespace`, `AsciiChar.equals`); `AsciiChar` stores a wrapped `Char`.
 - The stdlib also exposes `Char` as an `I32` wrapper (`struct Char { code: I32 }`) with namespaced helpers (`Char.from_code`, `Char.code`, `Char.equals`).
 - The stdlib now also exposes `Null` as an empty struct (`struct Null {}`) with namespaced constructor helper `Null.value()`.

--- a/agents/03-language-semantics.md
+++ b/agents/03-language-semantics.md
@@ -72,6 +72,7 @@ Observed in parser/IR implementation:
 - `String` is std-defined (in `std_string.oa`) as `enum String { Literal(Bytes), Heap(Bytes) }` with `Bytes { ptr: PtrInt, len: I32 }`; it is no longer a compiler primitive.
 - C interop signatures are std-defined via `extern fun`; compiler-side hardcoded libc JSON signatures were removed.
 - The split stdlib now uses namespaced helper APIs for JSON (`Json.*`) while JSON result enums remain top-level types (`ParseErr`, `ParseResult`, `JsonKind`).
+- The split stdlib `LinkedList[T]` template (in `std_collections.oa`) is persistent/value-based and now includes richer namespaced helpers (`empty`, `singleton`, `cons`, `push_front`, `is_empty`, `len`, `length`, `front`, `tail`, `pop_front`, `append`, `reverse`, `take`, `drop`, `at`, `at_or`) with result enums (`FrontResult`, `TailResult`, `PopFrontResult`); `length`, `head_or`, and `tail_or` are retained as compatibility wrappers.
 - The split stdlib also defines `AsciiChar` and `AsciiCharResult`; construction/parsing is explicit and fail-closed through `AsciiChar.from_code(...)` and `AsciiChar.from_string_at(...)` (returning `AsciiCharResult.OutOfRange` on invalid inputs). `AsciiChar` wraps `Char` and has an invariant requiring `0 <= Char.code(ch) <= 127`.
 - The split stdlib also defines `Char` as an `I32` wrapper (`struct Char { code: I32 }`) with helpers `Char.from_code(...)`, `Char.code(...)`, and `Char.equals(...)`.
 - The split stdlib now also defines `Null` as an empty struct (`struct Null {}`), with a namespaced constructor helper `Null.value() -> Null`.

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -115,7 +115,8 @@ Key tests:
   - `namespace_basic.oa`
 - Stdlib namespacing coverage in execution fixtures:
   - JSON helpers are exercised through `Json.*` calls in `json_parser.oa`, `json_document.oa`, and `json_scan_utils.oa`.
-  - Template stdlib helpers are exercised through namespaced call syntax (`IntList.*`, `IntTable.*`) in `template_linked_list_i32.oa` and `template_hash_table_i32.oa`.
+  - Template stdlib helpers are exercised through namespaced call syntax (`IntList.*`, `IntTable.*`) in `template_linked_list_i32.oa`, `template_linked_list_v2_i32.oa`, and `template_hash_table_i32.oa`.
+  - The v2 linked-list fixture (`template_linked_list_v2_i32.oa`) covers cached length (`len`), result-enum accessors (`front` / `tail` / `pop_front`), and transform helpers (`append`, `reverse`, `take`, `drop`, `at`, `at_or`) in addition to compatibility wrappers.
 
 Snapshots live in:
 - `crates/oac/src/snapshots/*.snap`

--- a/crates/oac/execution_tests/template_linked_list_v2_i32.oa
+++ b/crates/oac/execution_tests/template_linked_list_v2_i32.oa
@@ -1,0 +1,84 @@
+instantiate IntList = LinkedList[I32]
+
+fun print_front(v: IntList__FrontResult) -> I32 {
+	match v {
+		IntList__FrontResult.Empty => {
+			print(99)
+			return 0
+		}
+		IntList__FrontResult.Value(x) => {
+			print(x)
+			return 0
+		}
+	}
+}
+
+fun print_tail(v: IntList__TailResult) -> I32 {
+	match v {
+		IntList__TailResult.Empty => {
+			print(99)
+			return 0
+		}
+		IntList__TailResult.Value(rest) => {
+			print(IntList.len(rest))
+			return 0
+		}
+	}
+}
+
+fun print_pop(v: IntList__PopFrontResult) -> I32 {
+	match v {
+		IntList__PopFrontResult.Empty => {
+			print(99)
+			return 0
+		}
+		IntList__PopFrontResult.Value(r) => {
+			print(r.value)
+			print(IntList.len(r.rest))
+			return 0
+		}
+	}
+}
+
+fun main() -> I32 {
+	xs = IntList.empty()
+	print(IntList.len(xs))
+	print(IntList.length(xs))
+
+	xs = IntList.singleton(2)
+	xs = IntList.cons(1, xs)
+	xs = IntList.push_front(0, xs)
+	print(IntList.len(xs))
+	print(IntList.head_or(xs, 77))
+	print_front(IntList.front(xs))
+	print_tail(IntList.tail(xs))
+
+	print(IntList.at_or(xs, 1, 77))
+	print_front(IntList.at(xs, 2))
+	print_front(IntList.at(xs, 5))
+
+	tail = IntList.tail_or(xs, IntList.empty())
+	print(IntList.len(tail))
+	print_pop(IntList.pop_front(xs))
+
+	ys = IntList.push_front(4, IntList.push_front(3, IntList.empty()))
+	app = IntList.append(xs, ys)
+	print(IntList.len(app))
+	print(IntList.at_or(app, 4, 77))
+
+	rev = IntList.reverse(app)
+	print(IntList.at_or(rev, 0, 77))
+
+	taken = IntList.take(app, 3)
+	print(IntList.len(taken))
+	print(IntList.at_or(taken, 2, 77))
+
+	dropped = IntList.drop(app, 2)
+	print(IntList.len(dropped))
+	print(IntList.at_or(dropped, 0, 77))
+
+	print(IntList.len(IntList.take(app, 0 - 1)))
+	print(IntList.len(IntList.drop(app, 0 - 1)))
+
+	return 0
+}

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_linked_list_v2_i32.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_linked_list_v2_i32.oa.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oac/src/qbe_backend.rs
+assertion_line: 2249
+expression: output
+snapshot_kind: text
+---
+0
+0
+3
+0
+0
+2
+1
+2
+99
+2
+0
+2
+5
+3
+3
+3
+2
+3
+2
+0
+5

--- a/crates/oac/src/std_collections.oa
+++ b/crates/oac/src/std_collections.oa
@@ -1,5 +1,6 @@
 template LinkedList[T] {
 	struct Node {
+		len: I32,
 		value: T,
 		next: LinkedList,
 	}
@@ -9,12 +10,48 @@ template LinkedList[T] {
 		Cons(Node),
 	}
 
+	enum FrontResult {
+		Empty,
+		Value(T),
+	}
+
+	enum TailResult {
+		Empty,
+		Value(LinkedList),
+	}
+
+	struct PopFrontValue {
+		value: T,
+		rest: LinkedList,
+	}
+
+	enum PopFrontResult {
+		Empty,
+		Value(PopFrontValue),
+	}
+
 	fun empty() -> LinkedList {
 		return LinkedList.Empty
 	}
 
+	fun len(list: LinkedList) -> I32 {
+		return match list {
+			LinkedList.Empty => 0
+			LinkedList.Cons(node) => node.len
+		}
+	}
+
+	fun singleton(value: T) -> LinkedList {
+		return push_front(value, empty())
+	}
+
+	fun cons(value: T, list: LinkedList) -> LinkedList {
+		return push_front(value, list)
+	}
+
 	fun push_front(value: T, list: LinkedList) -> LinkedList {
 		node = Node struct {
+			len: len(list) + 1,
 			value: value,
 			next: list,
 		}
@@ -22,30 +59,168 @@ template LinkedList[T] {
 	}
 
 	fun is_empty(list: LinkedList) -> Bool {
+		return len(list) == 0
+	}
+
+	fun front(list: LinkedList) -> FrontResult {
 		return match list {
-			LinkedList.Empty => true
-			LinkedList.Cons(_node) => false
+			LinkedList.Empty => FrontResult.Empty
+			LinkedList.Cons(node) => FrontResult.Value(node.value)
+		}
+	}
+
+	fun tail(list: LinkedList) -> TailResult {
+		return match list {
+			LinkedList.Empty => TailResult.Empty
+			LinkedList.Cons(node) => TailResult.Value(node.next)
+		}
+	}
+
+	fun pop_front(list: LinkedList) -> PopFrontResult {
+		match list {
+			LinkedList.Empty => {
+				return PopFrontResult.Empty
+			}
+			LinkedList.Cons(node) => {
+				v = PopFrontValue struct {
+					value: node.value,
+					rest: node.next,
+				}
+				return PopFrontResult.Value(v)
+			}
 		}
 	}
 
 	fun head_or(list: LinkedList, fallback: T) -> T {
-		return match list {
-			LinkedList.Empty => fallback
-			LinkedList.Cons(node) => node.value
+		return match front(list) {
+			FrontResult.Empty => fallback
+			FrontResult.Value(value) => value
 		}
 	}
 
 	fun tail_or(list: LinkedList, fallback: LinkedList) -> LinkedList {
-		return match list {
-			LinkedList.Empty => fallback
-			LinkedList.Cons(node) => node.next
+		return match tail(list) {
+			TailResult.Empty => fallback
+			TailResult.Value(next) => next
 		}
 	}
 
 	fun length(list: LinkedList) -> I32 {
-		return match list {
-			LinkedList.Empty => 0
-			LinkedList.Cons(node) => 1 + length(node.next)
+		return len(list)
+	}
+
+	fun reverse(list: LinkedList) -> LinkedList {
+		cursor = list
+		out = empty()
+		while !is_empty(cursor) {
+			match cursor {
+				LinkedList.Empty => {
+					return out
+				}
+				LinkedList.Cons(node) => {
+					out = push_front(node.value, out)
+					cursor = node.next
+				}
+			}
+		}
+
+		return out
+	}
+
+	fun append(left: LinkedList, right: LinkedList) -> LinkedList {
+		cursor = reverse(left)
+		out = right
+		while !is_empty(cursor) {
+			match cursor {
+				LinkedList.Empty => {
+					return out
+				}
+				LinkedList.Cons(node) => {
+					out = push_front(node.value, out)
+					cursor = node.next
+				}
+			}
+		}
+
+		return out
+	}
+
+	fun take(list: LinkedList, count: I32) -> LinkedList {
+		if count <= 0 {
+			return empty()
+		}
+
+		cursor = list
+		remaining = count
+		out_rev = empty()
+		while remaining > 0 && !is_empty(cursor) {
+			match cursor {
+				LinkedList.Empty => {
+					return reverse(out_rev)
+				}
+				LinkedList.Cons(node) => {
+					out_rev = push_front(node.value, out_rev)
+					cursor = node.next
+					remaining = remaining - 1
+				}
+			}
+		}
+
+		return reverse(out_rev)
+	}
+
+	fun drop(list: LinkedList, count: I32) -> LinkedList {
+		if count <= 0 {
+			return list
+		}
+
+		cursor = list
+		remaining = count
+		while remaining > 0 && !is_empty(cursor) {
+			match cursor {
+				LinkedList.Empty => {
+					return empty()
+				}
+				LinkedList.Cons(node) => {
+					cursor = node.next
+					remaining = remaining - 1
+				}
+			}
+		}
+
+		return cursor
+	}
+
+	fun at(list: LinkedList, index: I32) -> FrontResult {
+		if index < 0 {
+			return FrontResult.Empty
+		}
+
+		cursor = list
+		i = 0
+		while !is_empty(cursor) {
+			match cursor {
+				LinkedList.Empty => {
+					return FrontResult.Empty
+				}
+				LinkedList.Cons(node) => {
+					if i == index {
+						return FrontResult.Value(node.value)
+					}
+
+					i = i + 1
+					cursor = node.next
+				}
+			}
+		}
+
+		return FrontResult.Empty
+	}
+
+	fun at_or(list: LinkedList, index: I32, fallback: T) -> T {
+		return match at(list, index) {
+			FrontResult.Empty => fallback
+			FrontResult.Value(value) => value
 		}
 	}
 }


### PR DESCRIPTION
Summary
- add richer cached-length metadata, helpers, and result enums to `LinkedList` along with persistent operations (`reverse`, `append`, `take`, `drop`, `at`, etc.)
- cover the new helpers in execution fixtures and document the behavior in `AGENTS` guidance files
- add a snapshot for the v2 linked list execution test to lock its expected output

Testing
- Not run (not requested)