### PR TITLE
Implement dynamic chaining HashTable and fix i32_to_i64 widening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - The stdlib also exposes `Char` as an `I32` wrapper (`struct Char { code: I32 }`) with namespaced helpers (`Char.from_code`, `Char.code`, `Char.equals`).
 - The stdlib now also exposes `Null` as an empty struct (`struct Null {}`) with namespaced constructor helper `Null.value()`.
 - The stdlib now also defines `Bytes` (`struct Bytes { ptr: PtrInt, len: I32 }`) and `String` as a tagged enum (`Literal(Bytes)` / `Heap(Bytes)`) in `std_string.oa`; `String` is no longer a compiler-primitive type.
+- The stdlib `HashTable[T]` in `std_collections.oa` is now a dynamically resizing separate-chaining map (persistent value semantics) with APIs `new`, `with_capacity`, `set` (`SetResult { table, inserted_new }`), `get`, `remove` (`RemoveResult { table, removed }`), `len`, `capacity`, `contains_key`, and `clear`; fixed-size `put`/`size` APIs were removed.
 - C interop in std is exposed through namespaced calls (`Clib.*`) and declared in `std_clib.oa` as `namespace Clib { extern fun ... }`; resolver keeps namespaced internal keys (`Clib__name`) while codegen emits declared extern symbol names for linking (for example `malloc`).
 - Built-in `Void` is available for C-style procedure signatures; in v1 only `extern fun` may return `Void`, and `Void` is rejected as a parameter type.
 - Built-in `U8` is available as an unsigned byte-like numeric type (`U8/U8` arithmetic and comparisons are allowed with no implicit coercions).

--- a/agents/03-language-semantics.md
+++ b/agents/03-language-semantics.md
@@ -78,6 +78,8 @@ Observed in parser/IR implementation:
 - The split stdlib also defines `AsciiChar` and `AsciiCharResult`; construction/parsing is explicit and fail-closed through `AsciiChar.from_code(...)` and `AsciiChar.from_string_at(...)` (returning `AsciiCharResult.OutOfRange` on invalid inputs). `AsciiChar` wraps `Char` and has an invariant requiring `0 <= Char.code(ch) <= 127`.
 - The split stdlib also defines `Char` as an `I32` wrapper (`struct Char { code: I32 }`) with helpers `Char.from_code(...)`, `Char.code(...)`, and `Char.equals(...)`.
 - The split stdlib now also defines `Null` as an empty struct (`struct Null {}`), with a namespaced constructor helper `Null.value() -> Null`.
+- The split stdlib now also defines `HashTable[T]` as a dynamically resizing separate-chaining map in `std_collections.oa`; public helpers are `HashTable.new`, `HashTable.with_capacity`, `HashTable.set`, `HashTable.get`, `HashTable.remove`, `HashTable.len`, `HashTable.capacity`, `HashTable.contains_key`, and `HashTable.clear`.
+- `HashTable.set` returns `SetResult { table: HashTable, inserted_new: Bool }` and `HashTable.remove` returns `RemoveResult { table: HashTable, removed: Lookup }`; `HashTable` keys are `I32`.
 - Struct invariants are optional per struct type and can be declared directly as `invariant "Human label" for (v: TypeName) { ... }` or `invariant identifier "Human label" for (...) { ... }`.
 - Invariant declarations synthesize internal functions named `__struct__<TypeName>__invariant` with signature `fun ...(v: <TypeName>) -> Bool`; legacy explicit functions using that exact name/signature are still accepted for compatibility.
 - Malformed legacy invariant functions are compile errors.
@@ -88,6 +90,7 @@ Observed in parser/IR implementation:
 - Checker construction inlines reachable user-function calls into the site checker before CHC encoding, so loops/control-flow are reasoned about on QBE transitions.
 - Runtime `assert(cond)` lowers to a branch that exits the process with code `242` and halts on failure.
 - String literals lower to std `String.Literal` values by allocating `Bytes` + tagged union wrapper in codegen; runtime string helpers (`char_at`, `string_len`, `slice`, `print_str`) read `Bytes.ptr`/`Bytes.len` from that layout.
+- Runtime `i32_to_i64` helper lowering uses signed extension (`extsw`) so values above `255` are not truncated in pointer/length conversion paths.
 - Solver assumptions include `argc >= 0` when `main` uses the `(argc: I32, argv: I64)` or `(argc: I32, argv: PtrInt)` form.
 - `oac test <file.oa>` is fail-fast: each `test` block is lowered to a generated zero-arg `I32` function, and a generated `main` executes tests in declaration order. A failing runtime `assert` exits immediately with code `242`.
 - `oac test` requires at least one `test` declaration and rejects source files that already define `main` (because `main` is synthesized by the test runner).

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -99,6 +99,7 @@ Key tests:
 - `crates/oac/src/qbe_backend.rs` test loads `crates/oac/execution_tests/*`, compiles fixtures, and snapshots either compiler errors or program stdout (non-zero exit codes are allowed; only spawn/timeout/signal/UTF-8 failures are runtime errors).
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts QBE emission for namespaced calls contains mangled function call symbols.
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts statement-position `Void` extern calls are emitted (`call $free`).
+- `crates/oac/src/qbe_backend.rs` also has a unit test that asserts `i32_to_i64` lowering uses signed extension (`extsw`) and not byte extension (`extub`).
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts FP32 lowering emits single-precision constants/ops and ordered float comparisons.
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts FP64 lowering emits double-precision constants/ops and ordered float comparisons.
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts `U8` lowers with unsigned comparison/division ops (`cultw`, `udiv`).
@@ -113,10 +114,13 @@ Key tests:
   - `assert_fail.oa`
 - Execution fixtures also include namespace call coverage:
   - `namespace_basic.oa`
+- Execution fixtures also include large-string length regression coverage:
+  - `string_len_large.oa`
 - Stdlib namespacing coverage in execution fixtures:
   - JSON helpers are exercised through `Json.*` calls in `json_parser.oa`, `json_document.oa`, and `json_scan_utils.oa`.
   - Template stdlib helpers are exercised through namespaced call syntax (`IntList.*`, `IntTable.*`) in `template_linked_list_i32.oa`, `template_linked_list_v2_i32.oa`, and `template_hash_table_i32.oa`.
   - The v2 linked-list fixture (`template_linked_list_v2_i32.oa`) covers cached length (`len`), result-enum accessors (`front` / `tail` / `pop_front`), and transform helpers (`append`, `reverse`, `take`, `drop`, `at`, `at_or`) in addition to compatibility wrappers.
+  - `template_hash_table_i32.oa` additionally covers HashTable v2 behaviors: `set/remove/len/capacity`, insert-vs-update semantics via `inserted_new`, and resize retention for existing entries.
 
 Snapshots live in:
 - `crates/oac/src/snapshots/*.snap`

--- a/crates/oac/execution_tests/string_len_large.oa
+++ b/crates/oac/execution_tests/string_len_large.oa
@@ -1,0 +1,5 @@
+fun main() -> I32 {
+	s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	print(string_len(s))
+	return 0
+}

--- a/crates/oac/execution_tests/template_hash_table_i32.oa
+++ b/crates/oac/execution_tests/template_hash_table_i32.oa
@@ -13,33 +13,71 @@ fun print_lookup(v: IntTable__Lookup) -> I32 {
 	}
 }
 
-fun main() -> I32 {
-	table = IntTable.empty()
-	print(IntTable.size(table))
+fun print_bool(v: Bool) -> I32 {
+	if v {
+		print(1)
+	} else {
+		print(0)
+	}
+	return 0
+}
 
-	table = IntTable.put(table, 1, 10)
-	table = IntTable.put(table, 9, 90)
-	table = IntTable.put(table, 2, 20)
-	print(IntTable.size(table))
+fun main() -> I32 {
+	table = IntTable.new()
+	print(IntTable.len(table))
+	print(IntTable.capacity(table))
+
+	r1 = IntTable.set(table, 1, 10)
+	table = r1.table
+	print_bool(r1.inserted_new)
+	r2 = IntTable.set(table, 9, 90)
+	table = r2.table
+	print_bool(r2.inserted_new)
+	r3 = IntTable.set(table, 17, 170)
+	table = r3.table
+	print_bool(r3.inserted_new)
+	print(IntTable.len(table))
 
 	print_lookup(IntTable.get(table, 1))
 	print_lookup(IntTable.get(table, 9))
+	print_lookup(IntTable.get(table, 17))
 	print_lookup(IntTable.get(table, 42))
 
-	table = IntTable.put(table, 1, 11)
-	print(IntTable.size(table))
+	r4 = IntTable.set(table, 1, 11)
+	table = r4.table
+	print_bool(r4.inserted_new)
+	print(IntTable.len(table))
 	print_lookup(IntTable.get(table, 1))
 
-	if IntTable.contains_key(table, 2) {
-		print(1)
-	} else {
-		print(0)
+	removed1 = IntTable.remove(table, 9)
+	table = removed1.table
+	print_lookup(removed1.removed)
+	print(IntTable.len(table))
+	print_lookup(IntTable.get(table, 9))
+
+	removed2 = IntTable.remove(table, 9)
+	table = removed2.table
+	print_lookup(removed2.removed)
+	print(IntTable.len(table))
+
+	print(IntTable.capacity(table))
+	i = 0
+	while i < 20 {
+		r = IntTable.set(table, 100 + i, i)
+		table = r.table
+		i = i + 1
 	}
-	if IntTable.contains_key(table, 42) {
-		print(1)
-	} else {
-		print(0)
-	}
+	print(IntTable.len(table))
+	print(IntTable.capacity(table))
+	print_lookup(IntTable.get(table, 1))
+	print_lookup(IntTable.get(table, 17))
+	print_lookup(IntTable.get(table, 119))
+	print_bool(IntTable.contains_key(table, 42))
+	print_bool(IntTable.contains_key(table, 119))
+
+	table = IntTable.clear(table)
+	print(IntTable.len(table))
+	print(IntTable.capacity(table))
 
 	return 0
 }

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__string_len_large.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__string_len_large.oa.snap
@@ -3,31 +3,4 @@ source: crates/oac/src/qbe_backend.rs
 expression: output
 snapshot_kind: text
 ---
-0
-8
-1
-1
-1
-3
-10
-90
-170
-99
-0
-3
-11
-90
-2
-99
-99
-2
-8
-22
-32
-11
-170
-19
-0
-1
-0
-32
+300

--- a/crates/oac/src/std_collections.oa
+++ b/crates/oac/src/std_collections.oa
@@ -231,9 +231,24 @@ template HashTable[T] {
 		value: T,
 	}
 
-	enum Slot {
+	struct EntryNode {
+		entry: Entry,
+		next: Bucket,
+	}
+
+	enum Bucket {
 		Empty,
-		Node(Entry),
+		Node(EntryNode),
+	}
+
+	struct BucketTreeNode {
+		left: Buckets,
+		right: Buckets,
+	}
+
+	enum Buckets {
+		Leaf(Bucket),
+		Branch(BucketTreeNode),
 	}
 
 	enum Lookup {
@@ -242,162 +257,460 @@ template HashTable[T] {
 	}
 
 	struct HashTable {
-		s0: Slot,
-		s1: Slot,
-		s2: Slot,
-		s3: Slot,
-		s4: Slot,
-		s5: Slot,
-		s6: Slot,
-		s7: Slot,
+		buckets: Buckets,
+		bucket_count: I32,
+		len: I32,
+		resize_threshold: I32,
 	}
 
-	fun empty() -> HashTable {
-		return HashTable struct { s0: Slot.Empty, s1: Slot.Empty, s2: Slot.Empty, s3: Slot.Empty, s4: Slot.Empty, s5: Slot.Empty, s6: Slot.Empty, s7: Slot.Empty, }
+	struct SetResult {
+		table: HashTable,
+		inserted_new: Bool,
 	}
 
-	fun hash_key(key: I32) -> I32 {
-		k = key
-		if k < 0 {
-			k = 0 - k
-		}
-
-		div = k / 8
-		return k - (div * 8)
+	struct RemoveResult {
+		table: HashTable,
+		removed: Lookup,
 	}
 
-	fun slot_at(table: HashTable, index: I32) -> Slot {
-		if index == 0 {
-			return table.s0
-		}
-		if index == 1 {
-			return table.s1
-		}
-		if index == 2 {
-			return table.s2
-		}
-		if index == 3 {
-			return table.s3
-		}
-		if index == 4 {
-			return table.s4
-		}
-		if index == 5 {
-			return table.s5
-		}
-		if index == 6 {
-			return table.s6
-		}
-
-		return table.s7
+	struct BucketSetResult {
+		bucket: Bucket,
+		inserted_new: Bool,
 	}
 
-	fun with_slot(table: HashTable, index: I32, slot: Slot) -> HashTable {
-		if index == 0 {
-			return HashTable struct { s0: slot, s1: table.s1, s2: table.s2, s3: table.s3, s4: table.s4, s5: table.s5, s6: table.s6, s7: table.s7, }
-		}
-		if index == 1 {
-			return HashTable struct { s0: table.s0, s1: slot, s2: table.s2, s3: table.s3, s4: table.s4, s5: table.s5, s6: table.s6, s7: table.s7, }
-		}
-		if index == 2 {
-			return HashTable struct { s0: table.s0, s1: table.s1, s2: slot, s3: table.s3, s4: table.s4, s5: table.s5, s6: table.s6, s7: table.s7, }
-		}
-		if index == 3 {
-			return HashTable struct { s0: table.s0, s1: table.s1, s2: table.s2, s3: slot, s4: table.s4, s5: table.s5, s6: table.s6, s7: table.s7, }
-		}
-		if index == 4 {
-			return HashTable struct { s0: table.s0, s1: table.s1, s2: table.s2, s3: table.s3, s4: slot, s5: table.s5, s6: table.s6, s7: table.s7, }
-		}
-		if index == 5 {
-			return HashTable struct { s0: table.s0, s1: table.s1, s2: table.s2, s3: table.s3, s4: table.s4, s5: slot, s6: table.s6, s7: table.s7, }
-		}
-		if index == 6 {
-			return HashTable struct { s0: table.s0, s1: table.s1, s2: table.s2, s3: table.s3, s4: table.s4, s5: table.s5, s6: slot, s7: table.s7, }
-		}
-
-		return HashTable struct { s0: table.s0, s1: table.s1, s2: table.s2, s3: table.s3, s4: table.s4, s5: table.s5, s6: table.s6, s7: slot, }
+	struct BucketRemoveResult {
+		bucket: Bucket,
+		removed: Lookup,
 	}
 
-	fun add_wrap(index: I32, delta: I32) -> I32 {
-		n = index + delta
-		if n >= 8 {
-			return n - 8
+	fun min_bucket_count() -> I32 {
+		return 8
+	}
+
+	fun threshold_for_capacity(capacity: I32) -> I32 {
+		threshold = (capacity * 3) / 4
+		if threshold < 1 {
+			return 1
 		}
+		return threshold
+	}
+
+	fun next_power_of_two(min_capacity: I32) -> I32 {
+		n = HashTable.min_bucket_count()
+		if min_capacity <= n {
+			return n
+		}
+
+		while n < min_capacity {
+			n = n + n
+		}
+
 		return n
 	}
 
-	fun put_probe(table: HashTable, start: I32, delta: I32, key: I32, value: T) -> HashTable {
-		if delta >= 8 {
-			return table
+	fun empty_buckets(count: I32) -> Buckets {
+		if count <= 1 {
+			return Buckets.Leaf(Bucket.Empty)
 		}
 
-		index = add_wrap(start, delta)
-		slot = slot_at(table, index)
-		match slot {
-			Slot.Empty => {
-				entry = Entry struct { key: key, value: value, }
-				return with_slot(table, index, Slot.Node(entry))
-			}
-			Slot.Node(entry) => {
-				if entry.key == key {
-					replaced = Entry struct { key: key, value: value, }
-					return with_slot(table, index, Slot.Node(replaced))
+		half = count / 2
+		left = HashTable.empty_buckets(half)
+		right = HashTable.empty_buckets(half)
+		node = BucketTreeNode struct {
+			left: left,
+			right: right,
+		}
+		return Buckets.Branch(node)
+	}
+
+	fun bucket_at(buckets: Buckets, count: I32, index: I32) -> Bucket {
+		if count <= 1 {
+			match buckets {
+				Buckets.Leaf(bucket) => {
+					return bucket
 				}
-				return put_probe(table, start, delta + 1, key, value)
+				Buckets.Branch(node) => {
+					return HashTable.bucket_at(node.left, 1, 0)
+				}
+			}
+		}
+
+		half = count / 2
+		match buckets {
+			Buckets.Leaf(bucket) => {
+				return bucket
+			}
+			Buckets.Branch(node) => {
+				if index < half {
+					return HashTable.bucket_at(node.left, half, index)
+				}
+				return HashTable.bucket_at(node.right, half, index - half)
 			}
 		}
 	}
 
-	fun get_probe(table: HashTable, start: I32, delta: I32, key: I32) -> Lookup {
-		if delta >= 8 {
-			return Lookup.Missing
+	fun with_bucket(buckets: Buckets, count: I32, index: I32, bucket: Bucket) -> Buckets {
+		if count <= 1 {
+			return Buckets.Leaf(bucket)
 		}
 
-		index = add_wrap(start, delta)
-		slot = slot_at(table, index)
-		match slot {
-			Slot.Empty => {
+		half = count / 2
+		match buckets {
+			Buckets.Leaf(_old) => {
+				return Buckets.Leaf(bucket)
+			}
+			Buckets.Branch(node) => {
+				if index < half {
+					left = HashTable.with_bucket(node.left, half, index, bucket)
+					updated = BucketTreeNode struct {
+						left: left,
+						right: node.right,
+					}
+					return Buckets.Branch(updated)
+				}
+				right = HashTable.with_bucket(node.right, half, index - half, bucket)
+				updated = BucketTreeNode struct {
+					left: node.left,
+					right: right,
+				}
+				return Buckets.Branch(updated)
+			}
+		}
+	}
+
+	fun modulo_non_negative(value: I32, divisor: I32) -> I32 {
+		q = value / divisor
+		r = value - (q * divisor)
+		if r < 0 {
+			return r + divisor
+		}
+		return r
+	}
+
+	fun bucket_index(key: I32, bucket_count: I32) -> I32 {
+		return HashTable.modulo_non_negative(key, bucket_count)
+	}
+
+	fun bucket_get(bucket: Bucket, key: I32) -> Lookup {
+		match bucket {
+			Bucket.Empty => {
 				return Lookup.Missing
 			}
-			Slot.Node(entry) => {
+			Bucket.Node(node) => {
+				entry = node.entry
 				if entry.key == key {
 					return Lookup.Found(entry.value)
 				}
-				return get_probe(table, start, delta + 1, key)
+				return HashTable.bucket_get(node.next, key)
 			}
 		}
 	}
 
-	fun slot_size(slot: Slot) -> I32 {
-		return match slot {
-			Slot.Empty => 0
-			Slot.Node(_entry) => 1
+	fun bucket_set(bucket: Bucket, key: I32, value: T) -> BucketSetResult {
+		match bucket {
+			Bucket.Empty => {
+				entry = Entry struct {
+					key: key,
+					value: value,
+				}
+				node = EntryNode struct {
+					entry: entry,
+					next: Bucket.Empty,
+				}
+				return BucketSetResult struct {
+					bucket: Bucket.Node(node),
+					inserted_new: true,
+				}
+			}
+			Bucket.Node(node) => {
+				entry = node.entry
+				if entry.key == key {
+					replaced_entry = Entry struct {
+						key: key,
+						value: value,
+					}
+					replaced_node = EntryNode struct {
+						entry: replaced_entry,
+						next: node.next,
+					}
+					return BucketSetResult struct {
+						bucket: Bucket.Node(replaced_node),
+						inserted_new: false,
+					}
+				}
+
+				tail = HashTable.bucket_set(node.next, key, value)
+				rebuilt = EntryNode struct {
+					entry: entry,
+					next: tail.bucket,
+				}
+				return BucketSetResult struct {
+					bucket: Bucket.Node(rebuilt),
+					inserted_new: tail.inserted_new,
+				}
+			}
 		}
 	}
 
-	fun put(table: HashTable, key: I32, value: T) -> HashTable {
-		start = hash_key(key)
-		return put_probe(table, start, 0, key, value)
+	fun bucket_remove(bucket: Bucket, key: I32) -> BucketRemoveResult {
+		match bucket {
+			Bucket.Empty => {
+				return BucketRemoveResult struct {
+					bucket: Bucket.Empty,
+					removed: Lookup.Missing,
+				}
+			}
+			Bucket.Node(node) => {
+				entry = node.entry
+				if entry.key == key {
+					return BucketRemoveResult struct {
+						bucket: node.next,
+						removed: Lookup.Found(entry.value),
+					}
+				}
+
+				tail = HashTable.bucket_remove(node.next, key)
+				rebuilt = EntryNode struct {
+					entry: entry,
+					next: tail.bucket,
+				}
+				return BucketRemoveResult struct {
+					bucket: Bucket.Node(rebuilt),
+					removed: tail.removed,
+				}
+			}
+		}
+	}
+
+	fun new() -> HashTable {
+		return HashTable.with_capacity(HashTable.min_bucket_count())
+	}
+
+	fun with_capacity(min_capacity: I32) -> HashTable {
+		cap = HashTable.next_power_of_two(min_capacity)
+		buckets = HashTable.empty_buckets(cap)
+		return HashTable struct {
+			buckets: buckets,
+			bucket_count: cap,
+			len: 0,
+			resize_threshold: HashTable.threshold_for_capacity(cap),
+		}
+	}
+
+	fun set_no_resize(table: HashTable, key: I32, value: T) -> SetResult {
+		index = HashTable.bucket_index(key, table.bucket_count)
+		bucket = HashTable.bucket_at(table.buckets, table.bucket_count, index)
+		bucket_result = HashTable.bucket_set(bucket, key, value)
+		next_buckets = HashTable.with_bucket(table.buckets, table.bucket_count, index, bucket_result.bucket)
+
+		next_len = table.len
+		if bucket_result.inserted_new {
+			next_len = next_len + 1
+		}
+
+		next_table = HashTable struct {
+			buckets: next_buckets,
+			bucket_count: table.bucket_count,
+			len: next_len,
+			resize_threshold: table.resize_threshold,
+		}
+		return SetResult struct {
+			table: next_table,
+			inserted_new: bucket_result.inserted_new,
+		}
+	}
+
+	fun insert_bucket_entries(dst: HashTable, bucket: Bucket) -> HashTable {
+		match bucket {
+			Bucket.Empty => {
+				return dst
+			}
+			Bucket.Node(node) => {
+				entry = node.entry
+				set_result = HashTable.set_no_resize(dst, entry.key, entry.value)
+				return HashTable.insert_bucket_entries(set_result.table, node.next)
+			}
+		}
+	}
+
+	fun insert_all_buckets(dst: HashTable, src: Buckets, count: I32) -> HashTable {
+		if count <= 1 {
+			match src {
+				Buckets.Leaf(bucket) => {
+					return HashTable.insert_bucket_entries(dst, bucket)
+				}
+				Buckets.Branch(node) => {
+					left = HashTable.insert_all_buckets(dst, node.left, 1)
+					return HashTable.insert_all_buckets(left, node.right, 1)
+				}
+			}
+		}
+
+		half = count / 2
+		match src {
+			Buckets.Leaf(bucket) => {
+				return HashTable.insert_bucket_entries(dst, bucket)
+			}
+			Buckets.Branch(node) => {
+				left = HashTable.insert_all_buckets(dst, node.left, half)
+				return HashTable.insert_all_buckets(left, node.right, half)
+			}
+		}
+	}
+
+	fun rehash(table: HashTable, new_bucket_count: I32) -> HashTable {
+		cap = HashTable.next_power_of_two(new_bucket_count)
+		fresh = HashTable.with_capacity(cap)
+		return HashTable.insert_all_buckets(fresh, table.buckets, table.bucket_count)
+	}
+
+	fun maybe_resize_before_insert(table: HashTable) -> HashTable {
+		if table.len + 1 > table.resize_threshold {
+			return HashTable.rehash(table, table.bucket_count + table.bucket_count)
+		}
+		return table
+	}
+
+	fun set(table: HashTable, key: I32, value: T) -> SetResult {
+		resized = HashTable.maybe_resize_before_insert(table)
+		return HashTable.set_no_resize(resized, key, value)
 	}
 
 	fun get(table: HashTable, key: I32) -> Lookup {
-		start = hash_key(key)
-		return get_probe(table, start, 0, key)
+		index = HashTable.bucket_index(key, table.bucket_count)
+		bucket = HashTable.bucket_at(table.buckets, table.bucket_count, index)
+		return HashTable.bucket_get(bucket, key)
+	}
+
+	fun remove(table: HashTable, key: I32) -> RemoveResult {
+		index = HashTable.bucket_index(key, table.bucket_count)
+		bucket = HashTable.bucket_at(table.buckets, table.bucket_count, index)
+		bucket_result = HashTable.bucket_remove(bucket, key)
+		next_buckets = HashTable.with_bucket(table.buckets, table.bucket_count, index, bucket_result.bucket)
+
+		next_len = table.len
+		match bucket_result.removed {
+			Lookup.Missing => {
+			}
+			Lookup.Found(_value) => {
+				next_len = next_len - 1
+			}
+		}
+
+		next_table = HashTable struct {
+			buckets: next_buckets,
+			bucket_count: table.bucket_count,
+			len: next_len,
+			resize_threshold: table.resize_threshold,
+		}
+		return RemoveResult struct {
+			table: next_table,
+			removed: bucket_result.removed,
+		}
+	}
+
+	fun clear(table: HashTable) -> HashTable {
+		buckets = HashTable.empty_buckets(table.bucket_count)
+		return HashTable struct {
+			buckets: buckets,
+			bucket_count: table.bucket_count,
+			len: 0,
+			resize_threshold: table.resize_threshold,
+		}
 	}
 
 	fun contains_key(table: HashTable, key: I32) -> Bool {
-		return match get(table, key) {
+		return match HashTable.get(table, key) {
 			Lookup.Missing => false
 			Lookup.Found(_value) => true
 		}
 	}
 
-	fun size(table: HashTable) -> I32 {
-		return slot_size(table.s0) + slot_size(table.s1) + slot_size(table.s2) + slot_size(table.s3) + slot_size(table.s4) + slot_size(table.s5) + slot_size(table.s6) + slot_size(table.s7)
+	fun len(table: HashTable) -> I32 {
+		return table.len
+	}
+
+	fun capacity(table: HashTable) -> I32 {
+		return table.bucket_count
 	}
 }
 
-test "A hashtable MUST have size 0 when created" {
-	table = HashTable.empty()
-	assert(HashTable.size(table) == 0)
+test "A hashtable MUST have len 0 when created" {
+	table = HashTable.new()
+	assert(HashTable.len(table) == 0)
+}
+
+test "A hashtable insert/get MUST work" {
+	r = HashTable.set(HashTable.new(), 10, 99)
+	table = r.table
+	assert(r.inserted_new)
+	assert(HashTable.len(table) == 1)
+	match HashTable.get(table, 10) {
+		HashTable__Lookup.Missing => {
+			assert(false)
+		}
+		HashTable__Lookup.Found(v) => {
+			assert(v == 99)
+		}
+	}
+}
+
+test "A hashtable update MUST not increase len" {
+	r1 = HashTable.set(HashTable.new(), 1, 10)
+	r2 = HashTable.set(r1.table, 1, 11)
+	if r2.inserted_new {
+		assert(false)
+	}
+	assert(HashTable.len(r2.table) == 1)
+	match HashTable.get(r2.table, 1) {
+		HashTable__Lookup.Missing => {
+			assert(false)
+		}
+		HashTable__Lookup.Found(v) => {
+			assert(v == 11)
+		}
+	}
+}
+
+test "A hashtable remove MUST decrease len" {
+	r1 = HashTable.set(HashTable.new(), 1, 10)
+	r2 = HashTable.set(r1.table, 9, 90)
+	removed = HashTable.remove(r2.table, 9)
+	assert(HashTable.len(removed.table) == 1)
+	match removed.removed {
+		HashTable__Lookup.Missing => {
+			assert(false)
+		}
+		HashTable__Lookup.Found(v) => {
+			assert(v == 90)
+		}
+	}
+}
+
+test "A hashtable resize MUST preserve entries" {
+	table = HashTable.new()
+	i = 0
+	while i < 20 {
+		r = HashTable.set(table, 100 + i, i)
+		table = r.table
+		i = i + 1
+	}
+	assert(HashTable.len(table) == 20)
+	assert(HashTable.capacity(table) >= 20)
+	match HashTable.get(table, 100) {
+		HashTable__Lookup.Missing => {
+			assert(false)
+		}
+		HashTable__Lookup.Found(v) => {
+			assert(v == 0)
+		}
+	}
+	match HashTable.get(table, 119) {
+		HashTable__Lookup.Missing => {
+			assert(false)
+		}
+		HashTable__Lookup.Found(v) => {
+			assert(v == 19)
+		}
+	}
 }


### PR DESCRIPTION
Summary
- switch `i32_to_i64` lowering to signed extension and add regression/unit coverage for the helper and long string lengths
- replace `HashTable[T]` with a persistent chaining design, expose `set/remove/len/capacity/with_capacity`, refresh template fixture + snapshot, and expand stdlib declaration tests
- document the new hashtable behavior and regression coverage across AGENTS/semantic/testing guides

Testing
- Not run (not requested)