### PR TITLE
Fix CI dependencies and update execution tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - name: Install z3
-        run: sudo apt-get update && sudo apt-get install -y z3
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
+      - name: Install backend dependencies
+        run: sudo apt-get update && sudo apt-get install -y z3 qbe
       - name: Install Rust
         run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
       - run: cargo check --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,13 @@ jobs:
         with:
           version: 0.13.0
       - name: Install backend dependencies
-        run: sudo apt-get update && sudo apt-get install -y z3 qbe
+        run: sudo apt-get update && sudo apt-get install -y z3
+      - name: Install qbe
+        run: |
+          curl -fsSL https://c9x.me/compile/release/qbe-1.2.tar.xz -o /tmp/qbe-1.2.tar.xz
+          tar -xf /tmp/qbe-1.2.tar.xz -C /tmp
+          make -C /tmp/qbe-1.2
+          sudo make -C /tmp/qbe-1.2 install
       - name: Install Rust
         run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
       - run: cargo check --all-targets --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - `oac build` now runs a best-effort non-termination classifier on the generated QBE `main` function; when it proves a canonical while-loop is non-terminating, compilation fails early with the loop header label and proof reason.
 - Build/test Zig linking now uses per-target writable cache directories (`target/oac/zig-global-cache`, `target/oac/zig-local-cache` or test equivalents) and fails closed on non-zero `zig cc` status.
 - Execution fixture snapshots in `qbe_backend` are based on program stdout even when the process exits with a non-zero code; runtime errors are reserved for spawn failures, timeouts, invalid UTF-8, or signal termination.
+- GitHub Actions CI now provisions backend test/build dependencies before Rust checks (`z3`, `qbe`, and Zig via `goto-bus-stop/setup-zig@v2`, pinned to `0.13.0` in `.github/workflows/ci.yml`).
 
 ## Hard-Cut Migration Cheatsheet
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - `oac build` now runs a best-effort non-termination classifier on the generated QBE `main` function; when it proves a canonical while-loop is non-terminating, compilation fails early with the loop header label and proof reason.
 - Build/test Zig linking now uses per-target writable cache directories (`target/oac/zig-global-cache`, `target/oac/zig-local-cache` or test equivalents) and fails closed on non-zero `zig cc` status.
 - Execution fixture snapshots in `qbe_backend` are based on program stdout even when the process exits with a non-zero code; runtime errors are reserved for spawn failures, timeouts, invalid UTF-8, or signal termination.
-- GitHub Actions CI now provisions backend test/build dependencies before Rust checks (`z3`, `qbe`, and Zig via `goto-bus-stop/setup-zig@v2`, pinned to `0.13.0` in `.github/workflows/ci.yml`).
+- GitHub Actions CI now provisions backend test/build dependencies before Rust checks (`z3`, Zig via `goto-bus-stop/setup-zig@v2` pinned to `0.13.0`, and `qbe` built from upstream `qbe-1.2` source tarball in `.github/workflows/ci.yml`).
 
 ## Hard-Cut Migration Cheatsheet
 

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -7,7 +7,7 @@ Defined in `.github/workflows/ci.yml`:
 - `cargo test --all-targets --all-features`
 - backend dependency provisioning before Rust checks:
   - `z3` (required for struct invariant/prove obligations)
-  - `qbe` (required for backend assembly generation in execution-style tests)
+  - `qbe` (required for backend assembly generation in execution-style tests; CI builds/installs upstream `qbe-1.2` from `https://c9x.me/compile/release/`)
   - Zig via `goto-bus-stop/setup-zig@v2` (pinned to `0.13.0`, used as `zig cc`)
 
 Any change should keep both green.

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -5,7 +5,10 @@
 Defined in `.github/workflows/ci.yml`:
 - `cargo check --all-targets --all-features`
 - `cargo test --all-targets --all-features`
-- `z3` installation (required for struct invariant verification obligations)
+- backend dependency provisioning before Rust checks:
+  - `z3` (required for struct invariant/prove obligations)
+  - `qbe` (required for backend assembly generation in execution-style tests)
+  - Zig via `goto-bus-stop/setup-zig@v2` (pinned to `0.13.0`, used as `zig cc`)
 
 Any change should keep both green.
 

--- a/crates/oac/execution_tests/generic_hash_table_custom_key.oa
+++ b/crates/oac/execution_tests/generic_hash_table_custom_key.oa
@@ -31,8 +31,8 @@ fun print_lookup(v: UserTable__Lookup) -> I32 {
 }
 
 fun main() -> I32 {
-	table = UserTable.empty()
-	print(UserTable.size(table))
+	table = UserTable.new()
+	print(UserTable.len(table))
 
 	a = UserKey struct {
 		id: 1,
@@ -47,9 +47,11 @@ fun main() -> I32 {
 		bucket: 7,
 	}
 
-	table = UserTable.put(table, a, 10)
-	table = UserTable.put(table, b, 20)
-	print(UserTable.size(table))
+	set_a = UserTable.set(table, a, 10)
+	table = set_a.table
+	set_b = UserTable.set(table, b, 20)
+	table = set_b.table
+	print(UserTable.len(table))
 
 	print_lookup(UserTable.get(table, a))
 	print_lookup(UserTable.get(table, b))

--- a/crates/oac/execution_tests/template_linked_list_v2_i32.oa
+++ b/crates/oac/execution_tests/template_linked_list_v2_i32.oa
@@ -1,4 +1,4 @@
-instantiate IntList = LinkedList[I32]
+specialize IntList = LinkedList[I32]
 
 fun print_front(v: IntList__FrontResult) -> I32 {
 	match v {


### PR DESCRIPTION
Summary
- ensure CI job installs Zig (via setup action) then backend deps (`z3`, `qbe`) before Rust tooling runs
- document the backend provisioning story in AGENTS and the CI testing guide
- adjust execution tests to use the new HashTable/LinkedList APIs (`set`/`len`, `specialize`)

Testing
- Not run (not requested)