### PR TITLE
Improve diagnostics quality and hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - The CLI now includes an `lsp` subcommand (`oac lsp`) that runs a stdio JSON-RPC language server with diagnostics.
 - The LSP currently handles text sync plus `textDocument/definition`, `textDocument/hover`, `textDocument/documentSymbol`, `textDocument/references`, and `textDocument/completion`.
 - Compiler diagnostics are centralized in `crates/oac/src/diagnostics.rs` and rendered with Ariadne for both CLI output and `oac lsp` diagnostic conversion.
-- `oac build` / `oac test` stage failures are now mapped to stable diagnostic codes (for example `OAC-PARSE-001`, `OAC-RESOLVE-001`) and emitted as Ariadne reports; execution fixture compilation-error snapshots therefore reflect Ariadne plain-report text.
+- `oac build` / `oac test` stage failures are now mapped to stable diagnostic codes (for example `OAC-PARSE-001`, `OAC-RESOLVE-001`, `OAC-LINK-001`, `OAC-LINK-002`) and emitted as Ariadne reports; execution fixture compilation-error snapshots therefore reflect Ariadne plain-report text.
 - A VS Code extension scaffold now lives in `tools/vscode-ousia/`; it launches `oac lsp` and is configured via `ousia.server.path`, `ousia.server.args`, and `ousia.trace.server`.
 - The VS Code extension must launch `oac lsp` without appending `--stdio`; `ousia.server.args` are sanitized to ignore `--stdio`.
 - Top-level tests use declaration syntax: `test "Name" { ... }`.
@@ -120,7 +120,9 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - Build/test environments that hit prove obligations also require `z3`; debug SMT artifacts are emitted under `target/oac/prove/`.
 - `oac build` now runs a best-effort non-termination classifier on the generated QBE `main` function; when it proves a canonical while-loop is non-terminating, compilation fails early with the loop header label and proof reason.
 - Build/test linking now uses C compiler drivers (`cc`/`clang`/target-prefixed `*-gcc`) instead of Zig. Link step is fail-closed and supports `OAC_CC` (single explicit command), `CC` (preferred first attempt), `OAC_CC_TARGET`, and `OAC_CC_FLAGS`.
+- Linker-stage diagnostics now use `DiagnosticStage::Linker` and stable codes `OAC-LINK-001` / `OAC-LINK-002` (legacy `OAC-ZIG-*` names are removed).
 - Execution fixture snapshots in `qbe_backend` are based on program stdout even when the process exits with a non-zero code; runtime errors are reserved for spawn failures, timeouts, invalid UTF-8, or signal termination.
+- Snapshot hygiene is test-gated: committed `*.snap.new` files, execution snapshots without matching `execution_tests/*.oa` fixtures, and duplicated Ariadne prefixes (`Error: error[...]`) are treated as test failures.
 - GitHub Actions CI now provisions backend test/build dependencies before Rust checks (`z3`, Zig via `goto-bus-stop/setup-zig@v2` pinned to `0.13.0`, and `qbe` built from upstream `qbe-1.2` source tarball in `.github/workflows/ci.yml`).
 
 ## Hard-Cut Migration Cheatsheet

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -97,6 +97,7 @@ Key tests:
 - `crates/qbe-smt/src/lib.rs` also covers Ariadne rendering helpers on `QbeSmtError` (`render_report_plain` / `render_report_terminal_auto`).
 - `crates/qbe-smt/src/lib.rs` also tests loop classification (`classify_simple_loops`) for proven non-termination patterns (identity updates, including `call $sub(..., 0)`) vs unknown/progress loops.
 - `crates/oac/src/diagnostics.rs` tests cover tokenizer span conversion, plain (no ANSI) report rendering, and no-span fallback rendering.
+- `crates/oac/src/diagnostics.rs` tests also enforce diagnostic headline quality for Ariadne plain reports (no duplicated `Error: error[...]` prefixing) and message/cause dedup behavior in `diagnostic_from_anyhow`.
 - `crates/oac/src/lsp.rs` tests cover diagnostics, definition/references lookup (including across flat imports), hover (including namespaced function calls), completion, document symbols, and file-URI handling.
 - `crates/oac/src/invariant_metadata.rs` tests cover multi-binding discovery per struct and argument-assumption cross-product expansion when parameter types carry multiple invariants.
 - `crates/oac/src/struct_invariants.rs` tests cover invariant discovery/validation for declaration-based invariants, grouped invariant declarations, legacy function-name compatibility, generic concrete-name support, obligation-site scoping, deterministic call-site ordinals, per-`(call-site, invariant)` obligation expansion, argument-invariant checker preconditions, recursion-cycle policy (call-only cycles allowed, cycles with arg-invariant edges rejected fail-closed), and module-level QBE-native checker synthesis/CHC encoding behavior (including modeled `memcpy` encoding and fail-closed unknown external calls).
@@ -105,6 +106,7 @@ Key tests:
 - `crates/oac/src/main.rs` tests cover build-time rejection when `main` contains a loop proven non-terminating by QBE loop classification.
 - `crates/oac/src/test_framework.rs` tests cover isolated lowering behavior for `oac test`: generated test functions/main plus error cases (no tests, user-defined `main`).
 - `crates/oac/src/qbe_backend.rs` test loads `crates/oac/execution_tests/*`, compiles fixtures, and snapshots either compiler errors or program stdout (non-zero exit codes are allowed; only spawn/timeout/signal/UTF-8 failures are runtime errors). Compiler-error snapshots now capture Ariadne plain-report output from the shared diagnostics layer.
+- `crates/oac/src/qbe_backend.rs` also enforces snapshot hygiene contracts for execution snapshots: no committed `*.snap.new` files, no orphan execution snapshots without matching fixtures, and no duplicated Ariadne prefix artifacts (`Error: error[...]`) in snapshot content.
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts QBE emission for namespaced calls contains mangled function call symbols.
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts statement-position `Void` extern calls are emitted (`call $free`).
 - `crates/oac/src/qbe_backend.rs` also has a unit test that asserts `i32_to_i64` lowering uses signed extension (`extsw`) and not byte extension (`extub`).
@@ -148,6 +150,7 @@ Snapshots live in:
 - `crates/oac/src/snapshots/*.snap`
 
 If behavior intentionally changes, update snapshots deliberately and review diffs for semantic regressions.
+Do not commit `.snap.new` files; accept or delete them before finishing.
 
 ## Runtime Tooling Dependencies
 
@@ -161,6 +164,7 @@ If behavior intentionally changes, update snapshots deliberately and review diff
 - `CC` to prefer a linker command first while still keeping default fallbacks
 - `OAC_CC_TARGET` to force `--target=<triple>`
 - `OAC_CC_FLAGS` to append extra linker flags
+- Linker diagnostics for this stage are reported under `DiagnosticStage::Linker` with stable codes `OAC-LINK-001` (configuration resolution) and `OAC-LINK-002` (all linker attempts failed).
 
 `oac test` has the same backend dependencies as `oac build` (`qbe`, C compiler driver, and `z3` when obligations are present), and additionally executes the produced binary under `target/oac/test/app`.
 

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -25,6 +25,7 @@ Act like a compiler engineer, not a text editor:
 - Preserve or explicitly migrate snapshot expectations.
 - Keep error messages actionable and stable where possible.
 - Route user-visible compiler errors through `crates/oac/src/diagnostics.rs` so CLI/LSP/snapshot behavior stays consistent (Ariadne plain output for deterministic tests).
+- Treat diagnostic quality as a product contract: avoid internal debug dumps in user-facing messages, avoid duplicated Ariadne prefixes (`Error: error[...]`), and keep linker-stage diagnostics on `OAC-LINK-*`.
 
 ## Pre-Release Compatibility Posture
 
@@ -62,6 +63,7 @@ Act like a compiler engineer, not a text editor:
 - `cargo nextest run --all-targets --all-features` (preferred when `cargo-nextest` is available)
 - `cargo test --all-targets --all-features` (fallback when `cargo-nextest` is unavailable)
 - Review snapshot diffs for unintended behavior changes.
+- Ensure snapshot hygiene gates pass (`*.snap.new` absent and execution snapshots aligned with fixtures).
 - Update docs in `agents/` and root `AGENTS.md` if any context changed.
 
 ## Autonomous Sync Rule (Mandatory)

--- a/crates/oac/src/prove.rs
+++ b/crates/oac/src/prove.rs
@@ -180,10 +180,17 @@ fn solve_prove_sites(
                 failure.push(')');
                 failures.push(failure);
             }
-            Ok(_run) => {
+            Ok(run) => {
+                let solver_excerpt = summarize_solver_output(&run.stdout, &run.stderr)
+                    .map(|excerpt| format!(", solver_excerpt={excerpt}"))
+                    .unwrap_or_default();
                 return Err(anyhow::anyhow!(
-                    "solver returned unknown for prove obligation {}",
-                    site.id
+                    "solver returned unknown for prove obligation {} (caller={}, qbe_artifact={}, smt_artifact={}{}). verification is fail-closed until this obligation is proven unsat",
+                    site.id,
+                    site.caller,
+                    qbe_filename,
+                    smt_filename,
+                    solver_excerpt
                 ));
             }
             Err(err) => {

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__comptime_purity_violation.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__comptime_purity_violation.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-COMPTIME-001] Error: error[comptime:OAC-COMPTIME-001]: failed to execute comptime applies: unsupported function call print in comptime evaluator (v1 is deterministic and pure)
+[OAC-COMPTIME-001] Error: failed to execute comptime applies: unsupported function call print in comptime evaluator (v1 is deterministic and pure)

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__comptime_transform_invalid_target.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__comptime_transform_invalid_target.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-COMPTIME-001] Error: error[comptime:OAC-COMPTIME-001]: failed to execute comptime applies: unknown comptime function missing_transform
+[OAC-COMPTIME-001] Error: failed to execute comptime applies: unknown comptime function missing_transform

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__double_function_definition.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__double_function_definition.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: failed to insert function signature for foo
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: failed to insert function signature for foo

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_ctor_invalid_arity.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_ctor_invalid_arity.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: expected 1 payload argument for constructor OptionI32.Some, got 2
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: expected 1 payload argument for constructor OptionI32.Some, got 2

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_ctor_wrong_payload_type.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_ctor_wrong_payload_type.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: mismatched payload type for OptionI32.Some: expected I32, got String
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: mismatched payload type for OptionI32.Some: expected I32, got String

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_invalid_variant.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_invalid_variant.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: variant Blue not found in enum Color
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: variant Blue not found in enum Color

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_duplicate_arm.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_duplicate_arm.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: duplicate match arm for variant Some
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: duplicate match arm for variant Some

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_non_exhaustive.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_non_exhaustive.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: non-exhaustive match on OptionI32: missing variants ["None"]
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: non-exhaustive match on OptionI32: missing variants ["None"]

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_payload_mismatch.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_match_payload_mismatch.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: match arm for non-payload variant None cannot bind a payload
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: match arm for non-payload variant None cannot bind a payload

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_payload_variant_without_call.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__enum_payload_variant_without_call.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: variant OptionI32.Some requires payload constructor call
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: variant OptionI32.Some requires payload constructor call

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_custom_key.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_custom_key.oa.snap
@@ -1,14 +1,8 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-assertion_line: 2608
 expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-INV-001] Error: error[struct-invariant:OAC-INV-001]: struct invariant verification failed: failed to solve struct invariant obligation UserTable__insert_all_buckets#0#13#coherent_state: failed to run z3: failed to send SMT query to z3: Broken pipe (os error 32)
-[QBE-SMT-001] Error: qbe-smt error
-   ╭─[ invariant-obligation:1:1 ]
-   │
-   │ 
-───╯
+[OAC-INV-001] Error: struct invariant verification failed: solver returned unknown for struct invariant obligation UserTable__insert_all_buckets#0#13 (caller=UserTable__insert_all_buckets, callee=UserTable__insert_all_buckets, struct=UserTable, invariant="hashtable metadata and structure must stay coherent (id=coherent_state)", qbe_artifact=site_UserTable__insert_all_buckets_0_13.qbe, smt_artifact=site_UserTable__insert_all_buckets_0_13.smt2). verification is fail-closed until this obligation is proven unsat

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_missing_impl.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_missing_impl.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: missing impl Hash for BadKey required by generic HashTable parameter K in specialization BadTable
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: missing impl Hash for BadKey required by generic HashTable parameter K in specialization BadTable

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__hello_world.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__hello_world.oa.snap
@@ -1,7 +1,0 @@
----
-source: crates/oac/src/qbe_backend.rs
-expression: output
----
-0
-1
-2

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__match_expr_non_exhaustive.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__match_expr_non_exhaustive.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: non-exhaustive match on Color: missing variants ["Green"]
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: non-exhaustive match on Color: missing variants ["Green"]

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__match_expr_type_mismatch.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__match_expr_type_mismatch.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: match expression arm type mismatch: expected "I32", got "Bool"
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: match expression arm type mismatch: expected "I32", got "Bool"

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fail.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fail.oa.snap
@@ -5,5 +5,5 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-PROVE-001] Error: error[prove:OAC-PROVE-001]: prove obligation verification failed: prove verification failed (SAT counterexamples found):
+[OAC-PROVE-001] Error: prove obligation verification failed: prove verification failed (SAT counterexamples found):
 main#0#1 (caller=main, qbe_artifact=site_main_0_1.qbe, smt_artifact=site_main_0_1.smt2)

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_statement_only.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_statement_only.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: prove(...) is statement-only and cannot be used as an expression
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: prove(...) is statement-only and cannot be used as an expression

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap
@@ -1,11 +1,8 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-expression: output
+expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
-65
-66
-1234
-1
-1
-1
+COMPILATION ERROR
+
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: mismatched types: expected "U8", but got "I32"

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_string_helpers.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_string_helpers.oa.snap
@@ -1,20 +1,9 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-expression: output
+expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
-1
-0
-1
-0
-1
-0
-97
-63
-5
-97
-4
-98
-97
-0
-1
+COMPILATION ERROR
+
+[OAC-INV-001] Error: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
+String__len#0#0 (caller=String__len, callee=String__bytes, struct=Bytes, invariant="bytes length must be non-negative (id=non_negative_length)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_String__len_0_0.qbe, smt_artifact=site_String__len_0_0.smt2)

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_bad_signature.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_bad_signature.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: invariant __struct__Counter__invariant must have signature fun __struct__Counter__invariant(v: Counter) -> Bool
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: invariant __struct__Counter__invariant must have signature fun __struct__Counter__invariant(v: Counter) -> Bool

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fail.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fail.oa.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-assertion_line: 2608
 expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-INV-001] Error: error[struct-invariant:OAC-INV-001]: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
-main#0#0#positive_value (caller=main, callee=make_counter, struct=Counter, invariant="counter value must be non-negative (id=positive_value)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_main_0_0_positive_value.qbe, smt_artifact=site_main_0_0_positive_value.smt2, program_input="main() has no inputs (counterexample is input-independent)")
+[OAC-INV-001] Error: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
+main#0#0 (caller=main, callee=make_counter, struct=Counter, invariant="counter value must be non-negative (id=positive_value)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_main_0_0.qbe, smt_artifact=site_main_0_0.smt2, program_input="main() has no inputs (counterexample is input-independent)")

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_pass_complex.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_pass_complex.oa.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-assertion_line: 2608
 expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-INV-001] Error: error[struct-invariant:OAC-INV-001]: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
-main#1#0#stable_envelope (caller=main, callee=make_envelope, struct=Envelope, invariant="envelope stays normalized and stable (id=stable_envelope)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_main_1_0_stable_envelope.qbe, smt_artifact=site_main_1_0_stable_envelope.smt2)
+[OAC-INV-001] Error: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
+main#1#0 (caller=main, callee=make_envelope, struct=Envelope, invariant="envelope stays normalized and stable (id=stable_envelope)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_main_1_0.qbe, smt_artifact=site_main_1_0.smt2)

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_hash_table_i32.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_hash_table_i32.oa.snap
@@ -1,14 +1,8 @@
 ---
 source: crates/oac/src/qbe_backend.rs
-assertion_line: 2608
 expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
 snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-INV-001] Error: error[struct-invariant:OAC-INV-001]: struct invariant verification failed: failed to solve struct invariant obligation IntTable__insert_all_buckets#0#13#coherent_state: failed to run z3: failed to send SMT query to z3: Broken pipe (os error 32)
-[QBE-SMT-001] Error: qbe-smt error
-   ╭─[ invariant-obligation:1:1 ]
-   │
-   │ 
-───╯
+[OAC-INV-001] Error: struct invariant verification failed: solver returned unknown for struct invariant obligation IntTable__insert_all_buckets#0#13 (caller=IntTable__insert_all_buckets, callee=IntTable__insert_all_buckets, struct=IntTable, invariant="hashtable metadata and structure must stay coherent (id=coherent_state)", qbe_artifact=site_IntTable__insert_all_buckets_0_13.qbe, smt_artifact=site_IntTable__insert_all_buckets_0_13.smt2). verification is fail-closed until this obligation is proven unsat

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_legacy_parentheses_syntax.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_legacy_parentheses_syntax.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-PARSE-001] Error: error[parse:OAC-PARSE-001]: failed to parse source: template syntax was removed; use `generic Name[T, ...] { ... }` instead
+[OAC-PARSE-001] Error: failed to parse source: template syntax was removed; use `generic Name[T, ...] { ... }` instead

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_missing_primary_type.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_missing_primary_type.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: generic Bad must define a primary type named Bad
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: generic Bad must define a primary type named Bad

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_unknown.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__template_unknown.oa.snap
@@ -5,4 +5,4 @@ snapshot_kind: text
 ---
 COMPILATION ERROR
 
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: unknown generic Missing in specialization X
+[OAC-RESOLVE-001] Error: failed to resolve/type-check program: unknown generic Missing in specialization X

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__todo_struct.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__todo_struct.oa.snap
@@ -1,7 +1,0 @@
----
-source: crates/oac/src/qbe_backend.rs
-expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
----
-COMPILATION ERROR
-
-Compilation of QBE IR to assembly failed: qbe:/var/folders/_p/sxbwvhbn2616zrnxntrthkyw0000gn/T/.tmpA7Q7Er/target/oac/ir.qbe:45: invalid type for second operand %.L_field_offset_a_019928bb83e07591bd2e0fb6249a8ceb in storew

--- a/crates/oac/src/struct_invariants.rs
+++ b/crates/oac/src/struct_invariants.rs
@@ -659,8 +659,26 @@ fn solve_obligations_qbe(
                     solver_excerpt
                 ));
             }
-            Ok(_run) => {
-                return Err(anyhow::anyhow!("solver returned unknown for {}", site.id));
+            Ok(run) => {
+                let solver_excerpt = summarize_solver_output(&run.stdout, &run.stderr)
+                    .map(|excerpt| format!(", solver_excerpt={excerpt}"))
+                    .unwrap_or_default();
+                let invariant_label = if let Some(identifier) = &site.invariant_identifier {
+                    format!("{} (id={})", site.invariant_display_name, identifier)
+                } else {
+                    site.invariant_display_name.clone()
+                };
+                return Err(anyhow::anyhow!(
+                    "solver returned unknown for struct invariant obligation {} (caller={}, callee={}, struct={}, invariant=\"{}\", qbe_artifact={}, smt_artifact={}{}). verification is fail-closed until this obligation is proven unsat",
+                    site.id,
+                    site.caller,
+                    site.callee,
+                    site.struct_name,
+                    invariant_label,
+                    qbe_filename,
+                    smt_filename,
+                    solver_excerpt
+                ));
             }
             Err(err) => {
                 return Err(anyhow::anyhow!(


### PR DESCRIPTION
Summary
- fix linker diagnostic metadata, error prefix rendering, and anyhow cause deduping for Ariadne reports
- enrich unsupported call target diagnostics and solver unknown messages with actionable info and artifacts
- add snapshot hygiene guards and doc updates in AGENTS instructions per new quality contract

Testing
- Not run (not requested)