### PR TITLE
Add nightly Git hooks for formatting and push-time tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+staged_rust_files=()
+while IFS= read -r file; do
+  staged_rust_files+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- "*.rs")
+
+if [[ ${#staged_rust_files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "pre-commit: rustup is required to run nightly rustfmt."
+  echo "Install rustup or bypass once with: git commit --no-verify"
+  exit 1
+fi
+
+rustfmt_bin="$(rustup which --toolchain nightly rustfmt 2>/dev/null || true)"
+if [[ -z "${rustfmt_bin}" || ! -x "${rustfmt_bin}" ]]; then
+  echo "pre-commit: nightly rustfmt is not available."
+  echo "Run: rustup toolchain install nightly --component rustfmt"
+  echo "Or bypass once with: git commit --no-verify"
+  exit 1
+fi
+
+echo "pre-commit: formatting staged Rust files with nightly rustfmt..."
+"${rustfmt_bin}" --config-path rustfmt.toml "${staged_rust_files[@]}"
+
+git add -- "${staged_rust_files[@]}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "pre-push: running Rust workspace tests..."
+
+if command -v cargo-nextest >/dev/null 2>&1; then
+  cargo nextest run --all-targets --all-features
+else
+  echo "pre-push: cargo-nextest not found; falling back to cargo test."
+  cargo test --all-targets --all-features
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 
 - For Rust test execution, use `cargo nextest run` when `cargo-nextest` is available in the environment (it is the preferred default because it is faster).
 - Fall back to `cargo test` only when `cargo-nextest` is unavailable or when parity with CI behavior must be verified explicitly.
+- Tracked Git hooks live under `.githooks/`; enable them locally with `git config core.hooksPath .githooks`.
+- The local `pre-commit` hook formats staged Rust files with nightly `rustfmt` (using `rustfmt.toml` with nightly import-sorting options), and the local `pre-push` hook runs Rust tests (`cargo nextest run --all-targets --all-features` with `cargo test` fallback).
 
 ## Current Syntax Notes
 

--- a/agents/01-repo-map.md
+++ b/agents/01-repo-map.md
@@ -45,6 +45,9 @@ Editor tooling in this repository:
 - `crates/oac/execution_tests/*.oa`: language behavior fixtures (positive + negative).
 - `crates/oac/src/snapshots/*.snap`: canonical snapshots for tests.
 - `.github/workflows/ci.yml`: CI checks (`cargo check`, `cargo test`).
+- `.githooks/pre-commit`: local Git hook that formats staged Rust files with nightly `rustfmt`.
+- `.githooks/pre-push`: local Git hook that runs workspace Rust tests before push.
+- `rustfmt.toml`: repository Rust formatting policy (nightly import-sorting behavior).
 
 ## Secondary/Reference Zones
 

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -56,6 +56,30 @@ npm run lint
 
 When debugging extension startup, verify the server command is exactly `oac lsp` (no extra `--stdio` argument).
 
+## Local Git Hooks
+
+This repository tracks local hooks under `.githooks/`.
+
+Enable once per clone/worktree:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Install/update formatter toolchain used by `pre-commit`:
+
+```bash
+rustup toolchain install nightly --component rustfmt
+```
+
+Hook behavior:
+- `pre-commit`: formats staged `*.rs` files with nightly `rustfmt` using `rustfmt.toml` (import sorting/grouping enabled for lower merge-conflict churn), then re-stages those files.
+- `pre-push`: runs Rust workspace tests on every push (`cargo nextest run --all-targets --all-features` preferred, `cargo test --all-targets --all-features` fallback when `cargo-nextest` is unavailable).
+
+Bypass for exceptional WIP cases:
+- `git commit --no-verify`
+- `git push --no-verify`
+
 ## Snapshot-Based Testing
 
 Key tests:

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -59,12 +59,18 @@ Act like a compiler engineer, not a text editor:
 
 ## Pre-Commit Checklist
 
+- One-time setup per clone/worktree: `git config core.hooksPath .githooks`
 - `cargo check --all-targets --all-features`
 - `cargo nextest run --all-targets --all-features` (preferred when `cargo-nextest` is available)
 - `cargo test --all-targets --all-features` (fallback when `cargo-nextest` is unavailable)
 - Review snapshot diffs for unintended behavior changes.
 - Ensure snapshot hygiene gates pass (`*.snap.new` absent and execution snapshots aligned with fixtures).
 - Update docs in `agents/` and root `AGENTS.md` if any context changed.
+
+Local hook policy in this repository:
+- `pre-commit` auto-formats staged Rust files with nightly `rustfmt` (`rustfmt.toml`).
+- `pre-push` runs workspace tests on every push (prefer `nextest`, fallback to `cargo test`).
+- Emergency bypass is explicit via `--no-verify`.
 
 ## Autonomous Sync Rule (Mandatory)
 

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap.new
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap.new
@@ -1,0 +1,9 @@
+---
+source: crates/oac/src/qbe_backend.rs
+assertion_line: 2704
+expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
+snapshot_kind: text
+---
+COMPILATION ERROR
+
+[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: mismatched types: expected "U8", but got "I32"

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap.new
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__std_mut_read_write.oa.snap.new
@@ -1,9 +1,0 @@
----
-source: crates/oac/src/qbe_backend.rs
-assertion_line: 2704
-expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
-snapshot_kind: text
----
-COMPILATION ERROR
-
-[OAC-RESOLVE-001] Error: error[resolve:OAC-RESOLVE-001]: failed to resolve/type-check program: mismatched types: expected "U8", but got "I32"

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_pass_complex.oa.snap.new
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_pass_complex.oa.snap.new
@@ -1,0 +1,10 @@
+---
+source: crates/oac/src/qbe_backend.rs
+assertion_line: 2738
+expression: "format!(\"COMPILATION ERROR\\n\\n{err}\")"
+snapshot_kind: text
+---
+COMPILATION ERROR
+
+[OAC-INV-001] Error: struct invariant verification failed: struct invariant verification failed (SAT counterexamples found):
+main#1#0#stable_envelope (caller=main, callee=make_envelope, struct=Envelope, invariant="envelope stays normalized and stable (id=stable_envelope)", witness=cfg_path=b0, bad_ret_temp=%si_bad, qbe_artifact=site_main_1_0_stable_envelope.qbe, smt_artifact=site_main_1_0_stable_envelope.smt2)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2021"
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+reorder_imports = true


### PR DESCRIPTION
## Summary
- add tracked Git hooks under `.githooks`
- run nightly rustfmt on staged Rust files in `pre-commit`
- run workspace tests in `pre-push` (nextest preferred, cargo test fallback)
- add `rustfmt.toml` nightly import-sorting settings
- document hook workflow in AGENTS and contributor docs

## Notes
- pushes can bypass hooks explicitly with `--no-verify` when needed
