### PR TITLE
Update pre-push hook to skip tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "pre-push: running Rust workspace tests..."
-
-if command -v cargo-nextest >/dev/null 2>&1; then
-  cargo nextest run --all-targets --all-features
-else
-  echo "pre-push: cargo-nextest not found; falling back to cargo test."
-  cargo test --all-targets --all-features
-fi
+echo "pre-push: no test checks configured in local hooks; continuing."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - For Rust test execution, use `cargo nextest run` when `cargo-nextest` is available in the environment (it is the preferred default because it is faster).
 - Fall back to `cargo test` only when `cargo-nextest` is unavailable or when parity with CI behavior must be verified explicitly.
 - Tracked Git hooks live under `.githooks/`; enable them locally with `git config core.hooksPath .githooks`.
-- The local `pre-commit` hook formats staged Rust files with nightly `rustfmt` (using `rustfmt.toml` with nightly import-sorting options), and the local `pre-push` hook runs Rust tests (`cargo nextest run --all-targets --all-features` with `cargo test` fallback).
+- The local `pre-commit` hook formats staged Rust files with nightly `rustfmt` (using `rustfmt.toml` with nightly import-sorting options), and the local `pre-push` hook is intentionally a no-op (no automatic test execution).
 
 ## Current Syntax Notes
 

--- a/agents/01-repo-map.md
+++ b/agents/01-repo-map.md
@@ -50,7 +50,7 @@ Editor tooling in this repository:
 - `crates/oac/src/snapshots/*.snap`: canonical snapshots for tests.
 - `.github/workflows/ci.yml`: CI checks (`cargo check`, `cargo test`).
 - `.githooks/pre-commit`: local Git hook that formats staged Rust files with nightly `rustfmt`.
-- `.githooks/pre-push`: local Git hook that runs workspace Rust tests before push.
+- `.githooks/pre-push`: local Git hook placeholder (no automatic test execution).
 - `rustfmt.toml`: repository Rust formatting policy (nightly import-sorting behavior).
 
 ## Secondary/Reference Zones

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -74,7 +74,7 @@ rustup toolchain install nightly --component rustfmt
 
 Hook behavior:
 - `pre-commit`: formats staged `*.rs` files with nightly `rustfmt` using `rustfmt.toml` (import sorting/grouping enabled for lower merge-conflict churn), then re-stages those files.
-- `pre-push`: runs Rust workspace tests on every push (`cargo nextest run --all-targets --all-features` preferred, `cargo test --all-targets --all-features` fallback when `cargo-nextest` is unavailable).
+- `pre-push`: no-op placeholder (does not run tests automatically).
 
 Bypass for exceptional WIP cases:
 - `git commit --no-verify`

--- a/agents/05-engineering-playbook.md
+++ b/agents/05-engineering-playbook.md
@@ -69,7 +69,7 @@ Act like a compiler engineer, not a text editor:
 
 Local hook policy in this repository:
 - `pre-commit` auto-formats staged Rust files with nightly `rustfmt` (`rustfmt.toml`).
-- `pre-push` runs workspace tests on every push (prefer `nextest`, fallback to `cargo test`).
+- `pre-push` is an intentional no-op placeholder (no automatic test execution on push).
 - Emergency bypass is explicit via `--no-verify`.
 
 ## Autonomous Sync Rule (Mandatory)


### PR DESCRIPTION
Summary
- drop the expensive `cargo nextest/cargo test` invocation from `.githooks/pre-push` and replace it with a note that no automated checks are configured
- update AGENTS.md, agents/01-repo-map.md, agents/04-testing-ci.md, and agents/05-engineering-playbook.md to document the pre-push hook change and keep the maintenance rule satisfied

Testing
- Not run (not requested)