### PR TITLE
Add FP32 support to proving pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,11 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - Build/test environments that hit invariant obligations require `z3`; debug SMT artifacts are emitted under `target/oac/struct_invariants/`.
 - `main` signatures are intentionally restricted to `fun main() -> I32`, `fun main(argc: I32, argv: I64) -> I32`, or `fun main(argc: I32, argv: PtrInt) -> I32`.
 - Solver encodings treat `argc` as non-negative by default (`argc >= 0`) when enabled by the caller.
-- `qbe-smt` is CHC-only (fixedpoint/Spacer): it emits Horn rules over QBE transitions and always queries whether halting with `exit == 1` is reachable.
+- `qbe-smt` is CHC-only (fixedpoint/Spacer): it emits Horn-style transition rules over QBE and always queries whether halting with `exit == 1` is reachable. Encoder scripts use `(set-logic HORN)` for non-FP obligations and `(set-logic ALL)` when reachable FP32 operations are present.
 - `qbe-smt` is strict fail-closed: unsupported instructions/operations are hard encoding errors (no conservative havoc fallback).
 - `qbe-smt` is parser-free and consumes in-memory QBE IR directly as modules (`qbe::Module` via `qbe_module_to_smt` / `qbe_module_to_smt_with_assumptions`).
-- `qbe-smt` remains fail-closed for floating-point obligations (including FP32/FP64 literals/comparisons); prove/struct-invariant obligations that require float reasoning are currently unsupported.
+- `qbe-smt` now supports FP32 obligations end-to-end in prove/struct-invariant checking for the currently emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and `loads`/`stores`) using SMT IEEE floating-point semantics with `RNE`.
+- `qbe-smt` remains fail-closed for FP64 obligations and unsupported float conversion ops (`exts`, `truncd`, `stosi`, `stoui`, `dtosi`, `dtoui`, `swtof`, `uwtof`, `sltof`, `ultof`).
 - Snapshot coverage now includes float-literal tokenizer fixtures and a parser AST snapshot regression (`parser_float_literals_ast`) to lock float literal parsing behavior.
 - `qbe-smt` CHC state now tracks predecessor-block identity (`pred`) so `phi` assignments are modeled directly in Horn transitions (with predecessor guards), instead of being rejected.
 - `qbe-smt` source split: `lib.rs` (public API + tests), `encode.rs` (core CHC/Horn encoding), `encode_extern_models.rs` (extern call model catalog/arity), `classify.rs` (loop classification).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,11 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - Build/test environments that hit invariant obligations require `z3`; debug SMT artifacts are emitted under `target/oac/struct_invariants/`.
 - `main` signatures are intentionally restricted to `fun main() -> I32`, `fun main(argc: I32, argv: I64) -> I32`, or `fun main(argc: I32, argv: PtrInt) -> I32`.
 - Solver encodings treat `argc` as non-negative by default (`argc >= 0`) when enabled by the caller.
-- `qbe-smt` is CHC-only (fixedpoint/Spacer): it emits Horn-style transition rules over QBE and always queries whether halting with `exit == 1` is reachable. Encoder scripts use `(set-logic HORN)` for non-FP obligations and `(set-logic ALL)` when reachable FP32 operations are present.
+- `qbe-smt` is CHC-only (fixedpoint/Spacer): it emits Horn-style transition rules over QBE and always queries whether halting with `exit == 1` is reachable. Encoder scripts use `(set-logic HORN)` for non-FP obligations and `(set-logic ALL)` when reachable FP32 or FP64 operations are present.
 - `qbe-smt` is strict fail-closed: unsupported instructions/operations are hard encoding errors (no conservative havoc fallback).
 - `qbe-smt` is parser-free and consumes in-memory QBE IR directly as modules (`qbe::Module` via `qbe_module_to_smt` / `qbe_module_to_smt_with_assumptions`).
-- `qbe-smt` now supports FP32 obligations end-to-end in prove/struct-invariant checking for the currently emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and `loads`/`stores`) using SMT IEEE floating-point semantics with `RNE`.
-- `qbe-smt` remains fail-closed for FP64 obligations and unsupported float conversion ops (`exts`, `truncd`, `stosi`, `stoui`, `dtosi`, `dtoui`, `swtof`, `uwtof`, `sltof`, `ultof`).
+- `qbe-smt` now supports FP32/FP64 obligations end-to-end in prove/struct-invariant checking for the currently emitted subset (FP32/FP64 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and `loads`/`stores`) using SMT IEEE floating-point semantics with `RNE`.
+- `qbe-smt` remains fail-closed for unsupported float conversion ops (`exts`, `truncd`, `stosi`, `stoui`, `dtosi`, `dtoui`, `swtof`, `uwtof`, `sltof`, `ultof`).
 - Snapshot coverage now includes float-literal tokenizer fixtures and a parser AST snapshot regression (`parser_float_literals_ast`) to lock float literal parsing behavior.
 - `qbe-smt` CHC state now tracks predecessor-block identity (`pred`) so `phi` assignments are modeled directly in Horn transitions (with predecessor guards), instead of being rejected.
 - `qbe-smt` source split: `lib.rs` (public API + tests), `encode.rs` (core CHC/Horn encoding), `encode_extern_models.rs` (extern call model catalog/arity), `classify.rs` (loop classification).

--- a/agents/02-compiler-pipeline.md
+++ b/agents/02-compiler-pipeline.md
@@ -179,8 +179,8 @@ Important enforced invariants include:
 - Bounded string-call details: `strlen` scans for NUL up to the inline limit and otherwise falls back to constrained unknown non-negative length; `strcmp` performs bounded first-event scan (`difference` or shared NUL) with tri-state results (`-1/0/1`) and otherwise falls back to unconstrained return.
 - `strcpy` memory effects are modeled as bounded byte copy until first NUL (including terminator); if no NUL is found within the inline limit, memory falls back to unconstrained `mem_next`.
 - Syscall-like modeled return constraints are explicit: `open` -> `-1 | >=0`, `close` -> `0 | -1`, `read`/`write` -> `-1 | (0 <= ret <= count)`.
-- FP32 obligations are supported in checker encoding for the emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32 `loads`/`stores`), and force `(set-logic ALL)` in the emitted SMT script.
-- FP64 obligations remain fail-closed unsupported in checker encoding (`Unsupported` errors).
+- FP32/FP64 obligations are supported in checker encoding for the emitted subset (FP32/FP64 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32/FP64 `loads`/`stores`), and force `(set-logic ALL)` in the emitted SMT script.
+- Unsupported float conversion operations remain fail-closed in checker encoding (`Unsupported` errors).
 - Encoding/validation is reachable-code-aware: only blocks reachable from function entry are flattened into Horn rules, so unreachable unsupported code does not block proving.
 - Main-argument-aware assumption remains available: when enabled and main has `argc`, encoding asserts `argc >= 0`.
 - Module-level argument assumptions are also available: `oac` now passes per-function invariant-bearing argument assumptions, and `qbe-smt` validates these references fail-closed (function exists/encoded, argument index in range, invariant target unary).

--- a/agents/02-compiler-pipeline.md
+++ b/agents/02-compiler-pipeline.md
@@ -163,11 +163,12 @@ Important enforced invariants include:
 - `qbe-smt` also owns CHC solver execution (`solve_chc_script`), so struct invariant verification now shares the same encode+solve backend path.
 - `main.rs` also uses `qbe-smt` loop classification on generated in-memory `main` QBE as an early non-termination guard.
 - `qbe-smt` is parser-free: it consumes in-memory QBE IR directly as modules (`qbe::Module` via `qbe_module_to_smt` / `qbe_module_to_smt_with_assumptions`). Internals are split by concern across `crates/qbe-smt/src/lib.rs` (API + tests), `crates/qbe-smt/src/encode.rs` (Horn encoding), `crates/qbe-smt/src/encode_extern_models.rs` (extern-call model/arity catalog), and `crates/qbe-smt/src/classify.rs` (loop classification).
-- `qbe-smt` models a broad integer + memory QBE subset:
+- `qbe-smt` models a broad integer + memory QBE subset plus an FP32 proving subset:
   - integer ALU/comparison ops (`add/sub/mul/div/rem`, unsigned variants, bitwise/shift ops)
+  - FP32 ALU/comparison ops (`add/sub/mul/div`, `eq/ne/lt/le/gt/ge/o/uo`) with IEEE semantics (`RNE`)
   - `phi` merging via predecessor-tracking state in CHC (`pred`)
   - `call` modeling for `malloc`, `free`, `calloc`, `realloc`, `memcpy`, `memmove`, `memcmp`, `memset`, `strlen`, `strcmp`, `strcpy`, `strncpy`, `open`, `read`, `write`, `close`, `exit(code)`, and variadic `printf` (for builtin `print` lowering)
-  - `load*`/`store*` byte-addressed memory operations
+  - `load*`/`store*` byte-addressed memory operations (including FP32 `loads`/`stores`)
   - `alloc4/alloc8/alloc16` heap-pointer modeling
   - control flow via Horn transition rules (`jnz`, `jmp`, `ret`, halt relation)
 - Register state is encoded as an SMT array and threaded through relation arguments.
@@ -178,7 +179,8 @@ Important enforced invariants include:
 - Bounded string-call details: `strlen` scans for NUL up to the inline limit and otherwise falls back to constrained unknown non-negative length; `strcmp` performs bounded first-event scan (`difference` or shared NUL) with tri-state results (`-1/0/1`) and otherwise falls back to unconstrained return.
 - `strcpy` memory effects are modeled as bounded byte copy until first NUL (including terminator); if no NUL is found within the inline limit, memory falls back to unconstrained `mem_next`.
 - Syscall-like modeled return constraints are explicit: `open` -> `-1 | >=0`, `close` -> `0 | -1`, `read`/`write` -> `-1 | (0 <= ret <= count)`.
-- Floating-point SMT reasoning is intentionally unsupported today; FP32/FP64 values/compares in obligations are rejected fail-closed.
+- FP32 obligations are supported in checker encoding for the emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32 `loads`/`stores`), and force `(set-logic ALL)` in the emitted SMT script.
+- FP64 obligations remain fail-closed unsupported in checker encoding (`Unsupported` errors).
 - Encoding/validation is reachable-code-aware: only blocks reachable from function entry are flattened into Horn rules, so unreachable unsupported code does not block proving.
 - Main-argument-aware assumption remains available: when enabled and main has `argc`, encoding asserts `argc >= 0`.
 - Module-level argument assumptions are also available: `oac` now passes per-function invariant-bearing argument assumptions, and `qbe-smt` validates these references fail-closed (function exists/encoded, argument index in range, invariant target unary).

--- a/agents/03-language-semantics.md
+++ b/agents/03-language-semantics.md
@@ -124,7 +124,8 @@ Observed in parser/IR implementation:
 - Prove obligations use the same CHC encoding/query shape (`exit == 1` reachability over synthesized checker QBE).
 - Struct-invariant proof obligations are solved via the shared `qbe-smt` CHC backend runner (Z3 invocation is centralized there).
 - `qbe-smt` is strict fail-closed: unsupported QBE operations are hard errors (no conservative havoc fallback).
-- `qbe-smt` currently rejects floating-point obligations fail-closed (including FP32/FP64 literals/comparisons) during prove/struct-invariant checking.
+- `qbe-smt` supports FP32 obligations during prove/struct-invariant checking for the emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32 `loads`/`stores`) using IEEE floating-point semantics with `RNE`.
+- `qbe-smt` remains fail-closed for FP64 obligations and unsupported float conversion operations.
 - `qbe-smt` models `call $exit(code)` as a halting transition with `exit` state set from `code`.
 - `qbe-smt` also models known CLib calls (`malloc`, `free`, `calloc`, `realloc`, `memcpy`, `memmove`, `memcmp`, `memset`, `strlen`, `strcmp`, `strcpy`, `strncpy`, `open`, `read`, `write`, `close`) plus variadic `printf` for builtin `print` inlined paths.
 - CLib byte-memory call models use bounded precise expansion (`limit = 16`) with sound fallback branches; unknown extern call targets remain fail-closed unsupported errors.

--- a/agents/03-language-semantics.md
+++ b/agents/03-language-semantics.md
@@ -124,8 +124,8 @@ Observed in parser/IR implementation:
 - Prove obligations use the same CHC encoding/query shape (`exit == 1` reachability over synthesized checker QBE).
 - Struct-invariant proof obligations are solved via the shared `qbe-smt` CHC backend runner (Z3 invocation is centralized there).
 - `qbe-smt` is strict fail-closed: unsupported QBE operations are hard errors (no conservative havoc fallback).
-- `qbe-smt` supports FP32 obligations during prove/struct-invariant checking for the emitted subset (FP32 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32 `loads`/`stores`) using IEEE floating-point semantics with `RNE`.
-- `qbe-smt` remains fail-closed for FP64 obligations and unsupported float conversion operations.
+- `qbe-smt` supports FP32/FP64 obligations during prove/struct-invariant checking for the emitted subset (FP32/FP64 args/results, `copy`, `add/sub/mul/div`, `cmp` `eq/ne/lt/le/gt/ge/o/uo`, `phi`, and FP32/FP64 `loads`/`stores`) using IEEE floating-point semantics with `RNE`.
+- `qbe-smt` remains fail-closed for unsupported float conversion operations.
 - `qbe-smt` models `call $exit(code)` as a halting transition with `exit` state set from `code`.
 - `qbe-smt` also models known CLib calls (`malloc`, `free`, `calloc`, `realloc`, `memcpy`, `memmove`, `memcmp`, `memset`, `strlen`, `strcmp`, `strcpy`, `strncpy`, `open`, `read`, `write`, `close`) plus variadic `printf` for builtin `print` inlined paths.
 - CLib byte-memory call models use bounded precise expansion (`limit = 16`) with sound fallback branches; unknown extern call targets remain fail-closed unsupported errors.

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -113,7 +113,7 @@ Key tests:
 - `crates/oac/src/ir.rs` also includes `U8` coverage for accepted same-type arithmetic/comparison and rejection of mixed `U8`/`I32` arithmetic.
 - `crates/oac/src/ir.rs` also includes resolve coverage for builtin pointer-memory helpers (`load_u8`, `load_i32`, `load_i64`, `load_bool`, `store_u8`, `store_i32`, `store_i64`, `store_bool`) with `PtrInt` addresses.
 - `crates/oac/src/ir.rs` also includes resolve/type-check coverage for std `Char` API usage together with char literals.
-- `crates/qbe-smt/src/lib.rs` tests (built from in-memory `qbe::Function` and `qbe::Module` fixtures) cover CHC/fixedpoint encoding shape (`HORN` for non-FP modules and `ALL` for FP32 modules, relation declarations, `(query bad)`), branch/loop rule generation, integer+memory modeling, FP32 proving subset modeling (`copy`/`add`/`sub`/`mul`/`div`, ordered/unordered compares, `phi`, FP32 `loads`/`stores`), interprocedural user-call summaries (including self-recursive user calls), argument-invariant precondition assumptions, explicit FP64 fail-closed rejection, and strict rejection of unsupported operations.
+- `crates/qbe-smt/src/lib.rs` tests (built from in-memory `qbe::Function` and `qbe::Module` fixtures) cover CHC/fixedpoint encoding shape (`HORN` for non-FP modules and `ALL` for FP32/FP64 modules, relation declarations, `(query bad)`), branch/loop rule generation, integer+memory modeling, FP32/FP64 proving subset modeling (`copy`/`add`/`sub`/`mul`/`div`, ordered/unordered compares, `phi`, FP32/FP64 `loads`/`stores`), interprocedural user-call summaries (including self-recursive user calls), argument-invariant precondition assumptions, fail-closed rejection for unsupported float conversions, and strict rejection of unsupported operations.
 - `crates/qbe-smt/src/lib.rs` validates modeled CLib call coverage (`memcpy`, `memmove`, `memcmp`, `memset`, `calloc`/`realloc`/`free`, bounded `strlen`/`strcmp`, bounded `strcpy`, and constrained `open`/`read`/`write`/`close` return modeling) in addition to `exit(code)` halting transitions and malformed exit-call rejection.
 - `crates/qbe-smt/src/lib.rs` additionally covers `phi` encoding via predecessor-state guards and rejection of malformed/unknown `phi` labels.
 - `crates/qbe-smt/src/lib.rs` also verifies reachable-only encoding behavior (unsupported instructions inside unreachable blocks are ignored).
@@ -145,12 +145,15 @@ Key tests:
 - Execution fixtures now include dedicated prove/assert coverage:
   - `prove_pass.oa`
   - `prove_fp32_pass.oa`
+  - `prove_fp64_pass.oa`
   - `prove_fail.oa`
   - `prove_statement_only.oa`
   - `assert_pass.oa`
   - `assert_fail.oa`
 - Execution fixtures also include FP32 struct-invariant proving coverage:
   - `struct_invariant_fp32_pass.oa`
+- Execution fixtures also include FP64 struct-invariant proving coverage:
+  - `struct_invariant_fp64_pass.oa`
 - Execution fixtures also include namespace call coverage:
   - `namespace_basic.oa`
 - Execution fixtures also include large-string length regression coverage:

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -113,7 +113,7 @@ Key tests:
 - `crates/oac/src/ir.rs` also includes `U8` coverage for accepted same-type arithmetic/comparison and rejection of mixed `U8`/`I32` arithmetic.
 - `crates/oac/src/ir.rs` also includes resolve coverage for builtin pointer-memory helpers (`load_u8`, `load_i32`, `load_i64`, `load_bool`, `store_u8`, `store_i32`, `store_i64`, `store_bool`) with `PtrInt` addresses.
 - `crates/oac/src/ir.rs` also includes resolve/type-check coverage for std `Char` API usage together with char literals.
-- `crates/qbe-smt/src/lib.rs` tests (built from in-memory `qbe::Function` and `qbe::Module` fixtures) cover CHC/fixedpoint encoding shape (`HORN`, relation declarations, `(query bad)`), branch/loop rule generation, integer+memory modeling, interprocedural user-call summaries (including self-recursive user calls), argument-invariant precondition assumptions, and strict rejection of unsupported operations.
+- `crates/qbe-smt/src/lib.rs` tests (built from in-memory `qbe::Function` and `qbe::Module` fixtures) cover CHC/fixedpoint encoding shape (`HORN` for non-FP modules and `ALL` for FP32 modules, relation declarations, `(query bad)`), branch/loop rule generation, integer+memory modeling, FP32 proving subset modeling (`copy`/`add`/`sub`/`mul`/`div`, ordered/unordered compares, `phi`, FP32 `loads`/`stores`), interprocedural user-call summaries (including self-recursive user calls), argument-invariant precondition assumptions, explicit FP64 fail-closed rejection, and strict rejection of unsupported operations.
 - `crates/qbe-smt/src/lib.rs` validates modeled CLib call coverage (`memcpy`, `memmove`, `memcmp`, `memset`, `calloc`/`realloc`/`free`, bounded `strlen`/`strcmp`, bounded `strcpy`, and constrained `open`/`read`/`write`/`close` return modeling) in addition to `exit(code)` halting transitions and malformed exit-call rejection.
 - `crates/qbe-smt/src/lib.rs` additionally covers `phi` encoding via predecessor-state guards and rejection of malformed/unknown `phi` labels.
 - `crates/qbe-smt/src/lib.rs` also verifies reachable-only encoding behavior (unsupported instructions inside unreachable blocks are ignored).
@@ -144,10 +144,13 @@ Key tests:
 - `crates/qbe-rs/src/tests.rs` includes coverage for FP32/FP64 constant formatting (`s_<literal>`, `d_<literal>`) and ordered float compare formatting (`clts`, `cgtd`).
 - Execution fixtures now include dedicated prove/assert coverage:
   - `prove_pass.oa`
+  - `prove_fp32_pass.oa`
   - `prove_fail.oa`
   - `prove_statement_only.oa`
   - `assert_pass.oa`
   - `assert_fail.oa`
+- Execution fixtures also include FP32 struct-invariant proving coverage:
+  - `struct_invariant_fp32_pass.oa`
 - Execution fixtures also include namespace call coverage:
   - `namespace_basic.oa`
 - Execution fixtures also include large-string length regression coverage:

--- a/crates/oac/execution_tests/prove_fp32_pass.oa
+++ b/crates/oac/execution_tests/prove_fp32_pass.oa
@@ -1,0 +1,7 @@
+fun main() -> I32 {
+	a = 1.25
+	b = 2.5
+	prove(a < b)
+	print(42)
+	return 0
+}

--- a/crates/oac/execution_tests/prove_fp64_pass.oa
+++ b/crates/oac/execution_tests/prove_fp64_pass.oa
@@ -1,0 +1,7 @@
+fun main() -> I32 {
+	a = 1.25f64
+	b = 2.5f64
+	prove(a < b)
+	print(64)
+	return 0
+}

--- a/crates/oac/execution_tests/struct_invariant_fp32_pass.oa
+++ b/crates/oac/execution_tests/struct_invariant_fp32_pass.oa
@@ -1,0 +1,19 @@
+struct Foo {
+	x: FP32,
+}
+
+invariant "x is bounded above by one" for (v: Foo) {
+	return v.x <= 1.0
+}
+
+fun make_foo(x: FP32) -> Foo {
+	return Foo struct { x: x, }
+}
+
+fun main() -> I32 {
+	f = make_foo(0.5)
+	if f.x < 1.0 {
+		print(1)
+	}
+	return 0
+}

--- a/crates/oac/execution_tests/struct_invariant_fp64_pass.oa
+++ b/crates/oac/execution_tests/struct_invariant_fp64_pass.oa
@@ -1,0 +1,19 @@
+struct Foo {
+	x: FP64,
+}
+
+invariant "x is bounded above by one" for (v: Foo) {
+	return v.x <= 1.0f64
+}
+
+fun make_foo(x: FP64) -> Foo {
+	return Foo struct { x: x, }
+}
+
+fun main() -> I32 {
+	f = make_foo(0.5f64)
+	if f.x < 1.0f64 {
+		print(2)
+	}
+	return 0
+}

--- a/crates/oac/src/prove.rs
+++ b/crates/oac/src/prove.rs
@@ -535,6 +535,24 @@ fun main() -> I32 {
     }
 
     #[test]
+    fn prove_sites_support_fp64_obligations() {
+        let source = r#"
+fun main() -> I32 {
+	a = 1.25f64
+	b = 2.5f64
+	prove(a < b)
+	return 0
+}
+"#;
+
+        let program = resolve_program(source);
+        let qbe_module = qbe_backend::compile(program.clone());
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        verify_prove_obligations_with_qbe(&program, &qbe_module, tempdir.path())
+            .expect("FP64 prove obligations should verify");
+    }
+
+    #[test]
     fn prove_checker_encoding_models_string_and_io_clib_calls() {
         let source = r#"
 fun check(path: PtrInt, fd: Int, buf: PtrInt, n: PtrInt) -> I32 {

--- a/crates/oac/src/prove.rs
+++ b/crates/oac/src/prove.rs
@@ -517,6 +517,24 @@ fun main() -> I32 {
     }
 
     #[test]
+    fn prove_sites_support_fp32_obligations() {
+        let source = r#"
+fun main() -> I32 {
+	a = 1.25
+	b = 2.5
+	prove(a < b)
+	return 0
+}
+"#;
+
+        let program = resolve_program(source);
+        let qbe_module = qbe_backend::compile(program.clone());
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        verify_prove_obligations_with_qbe(&program, &qbe_module, tempdir.path())
+            .expect("FP32 prove obligations should verify");
+    }
+
+    #[test]
     fn prove_checker_encoding_models_string_and_io_clib_calls() {
         let source = r#"
 fun check(path: PtrInt, fd: Int, buf: PtrInt, n: PtrInt) -> I32 {

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_custom_key.oa.snap.new
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__generic_hash_table_custom_key.oa.snap.new
@@ -1,9 +1,0 @@
----
-source: crates/oac/src/qbe_backend.rs
-assertion_line: 2808
-expression: snapshot_content
-snapshot_kind: text
----
-COMPILATION ERROR
-
-[OAC-INV-001] Error: struct invariant verification failed: solver returned unknown for struct invariant obligation UserTable__insert_all_buckets#0#13#coherent_state (caller=UserTable__insert_all_buckets, callee=UserTable__insert_all_buckets, struct=UserTable, invariant="hashtable metadata and structure must stay coherent (id=coherent_state)", qbe_artifact=site_UserTable__insert_all_buckets_0_13_coherent_state.qbe, smt_artifact=site_UserTable__insert_all_buckets_0_13_coherent_state.smt2). verification is fail-closed until this obligation is proven unsat

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fp32_pass.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fp32_pass.oa.snap
@@ -1,0 +1,6 @@
+---
+source: crates/oac/src/qbe_backend.rs
+expression: snapshot_content
+snapshot_kind: text
+---
+42

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fp64_pass.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__prove_fp64_pass.oa.snap
@@ -1,0 +1,6 @@
+---
+source: crates/oac/src/qbe_backend.rs
+expression: snapshot_content
+snapshot_kind: text
+---
+64

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fp32_pass.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fp32_pass.oa.snap
@@ -1,0 +1,6 @@
+---
+source: crates/oac/src/qbe_backend.rs
+expression: snapshot_content
+snapshot_kind: text
+---
+1

--- a/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fp64_pass.oa.snap
+++ b/crates/oac/src/snapshots/oac__qbe_backend__tests__execution_tests__struct_invariant_fp64_pass.oa.snap
@@ -1,0 +1,6 @@
+---
+source: crates/oac/src/qbe_backend.rs
+expression: snapshot_content
+snapshot_kind: text
+---
+2

--- a/crates/oac/src/struct_invariants.rs
+++ b/crates/oac/src/struct_invariants.rs
@@ -1625,6 +1625,35 @@ fun main() -> I32 {
     }
 
     #[test]
+    fn fp64_struct_invariants_verify_in_qbe_native_flow() {
+        let program = resolve_program(
+            r#"
+struct Foo {
+	x: FP64,
+}
+
+invariant "x is bounded above by one" for (v: Foo) {
+	return v.x <= 1.0f64
+}
+
+fun make_foo(x: FP64) -> Foo {
+	return Foo struct { x: x, }
+}
+
+fun main() -> I32 {
+	f = make_foo(0.5f64)
+	return 0
+}
+"#,
+        );
+
+        let qbe_module = compile_qbe(&program);
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        verify_struct_invariants_with_qbe(&program, &qbe_module, tempdir.path())
+            .expect("FP64 struct invariants should verify");
+    }
+
+    #[test]
     fn unknown_external_calls_fail_closed_in_qbe_native_flow() {
         let program = resolve_program(
             r#"

--- a/crates/oac/src/struct_invariants.rs
+++ b/crates/oac/src/struct_invariants.rs
@@ -1596,6 +1596,35 @@ fun main(argc: I32, argv: PtrInt) -> I32 {
     }
 
     #[test]
+    fn fp32_struct_invariants_verify_in_qbe_native_flow() {
+        let program = resolve_program(
+            r#"
+struct Foo {
+	x: FP32,
+}
+
+invariant "x is bounded above by one" for (v: Foo) {
+	return v.x <= 1.0
+}
+
+fun make_foo(x: FP32) -> Foo {
+	return Foo struct { x: x, }
+}
+
+fun main() -> I32 {
+	f = make_foo(0.5)
+	return 0
+}
+"#,
+        );
+
+        let qbe_module = compile_qbe(&program);
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        verify_struct_invariants_with_qbe(&program, &qbe_module, tempdir.path())
+            .expect("FP32 struct invariants should verify");
+    }
+
+    #[test]
     fn unknown_external_calls_fail_closed_in_qbe_native_flow() {
         let program = resolve_program(
             r#"

--- a/crates/qbe-smt/src/encode.rs
+++ b/crates/qbe-smt/src/encode.rs
@@ -20,7 +20,11 @@ pub(crate) fn encode_module(
     let context = build_module_encoding_context(module, entry, assumptions)?;
 
     let mut smt = String::new();
-    smt.push_str("(set-logic HORN)\n");
+    if context.uses_fp32 {
+        smt.push_str("(set-logic ALL)\n");
+    } else {
+        smt.push_str("(set-logic HORN)\n");
+    }
     smt.push_str("(set-option :fp.engine spacer)\n");
     smt.push_str("(set-info :source |qbe-smt chc fixedpoint model|)\n\n");
 
@@ -528,6 +532,7 @@ struct ModuleEncodingContext {
     global_map: HashMap<String, u64>,
     arg_invariant_assumptions: HashMap<String, Vec<ValidatedArgInvariantAssumption>>,
     max_arg_invariant_assumptions: usize,
+    uses_fp32: bool,
 }
 
 fn build_module_encoding_context(
@@ -661,6 +666,7 @@ fn build_module_encoding_context(
 
     let mut functions = HashMap::new();
     let mut globals = BTreeSet::<String>::new();
+    let mut uses_fp32 = false;
     for (function_id, function_name) in function_order.iter().enumerate() {
         let function = function_map
             .get(function_name)
@@ -706,6 +712,11 @@ fn build_module_encoding_context(
         }
         for arg_name in arg_names {
             globals.remove(&arg_name);
+        }
+        if args.iter().any(|arg| arg.ty == AssignType::Single)
+            || flattened.statements.iter().any(statement_uses_fp32)
+        {
+            uses_fp32 = true;
         }
 
         functions.insert(
@@ -755,6 +766,7 @@ fn build_module_encoding_context(
         global_map,
         arg_invariant_assumptions: encoded_arg_invariant_assumptions,
         max_arg_invariant_assumptions,
+        uses_fp32,
     })
 }
 
@@ -1414,7 +1426,7 @@ fn collect_function_args(function: &QbeFunction) -> Result<Vec<FunctionArg>, Qbe
         };
 
         let assign_ty = assign_type_from_qbe(ty);
-        if matches!(assign_ty, AssignType::Single | AssignType::Double) {
+        if matches!(assign_ty, AssignType::Double) {
             return Err(QbeSmtError::Unsupported {
                 message: format!(
                     "unsupported floating-point function argument `%{}` in CHC encoding",
@@ -1455,15 +1467,21 @@ fn validate_statement_supported(
                 | QbeInstr::Sub(..)
                 | QbeInstr::Mul(..)
                 | QbeInstr::Div(..)
-                | QbeInstr::Udiv(..)
+                | QbeInstr::Copy(..) => {
+                    if matches!(assign_ty, AssignType::Double) {
+                        return Err(QbeSmtError::Unsupported {
+                            message: format!("pc {pc}: floating-point assignments are unsupported"),
+                        });
+                    }
+                }
+                QbeInstr::Udiv(..)
                 | QbeInstr::Rem(..)
                 | QbeInstr::Urem(..)
                 | QbeInstr::And(..)
                 | QbeInstr::Or(..)
                 | QbeInstr::Shl(..)
                 | QbeInstr::Shr(..)
-                | QbeInstr::Sar(..)
-                | QbeInstr::Copy(..) => {
+                | QbeInstr::Sar(..) => {
                     if matches!(assign_ty, AssignType::Single | AssignType::Double) {
                         return Err(QbeSmtError::Unsupported {
                             message: format!("pc {pc}: floating-point assignments are unsupported"),
@@ -1472,11 +1490,40 @@ fn validate_statement_supported(
                 }
                 QbeInstr::Cmp(cmp_ty, kind, ..) => {
                     let cmp_assign_ty = assign_type_from_qbe(cmp_ty);
-                    if matches!(
-                        kind,
-                        QbeCmp::O | QbeCmp::Uo | QbeCmp::Lt | QbeCmp::Le | QbeCmp::Gt | QbeCmp::Ge
-                    ) || matches!(assign_ty, AssignType::Single | AssignType::Double)
-                        || matches!(cmp_assign_ty, AssignType::Single | AssignType::Double)
+                    let cmp_kind_supported = match cmp_assign_ty {
+                        AssignType::Single => matches!(
+                            kind,
+                            QbeCmp::Eq
+                                | QbeCmp::Ne
+                                | QbeCmp::Lt
+                                | QbeCmp::Le
+                                | QbeCmp::Gt
+                                | QbeCmp::Ge
+                                | QbeCmp::O
+                                | QbeCmp::Uo
+                        ),
+                        AssignType::Word | AssignType::Long => matches!(
+                            kind,
+                            QbeCmp::Eq
+                                | QbeCmp::Ne
+                                | QbeCmp::Slt
+                                | QbeCmp::Sle
+                                | QbeCmp::Sgt
+                                | QbeCmp::Sge
+                                | QbeCmp::Ult
+                                | QbeCmp::Ule
+                                | QbeCmp::Ugt
+                                | QbeCmp::Uge
+                        ),
+                        AssignType::Double => false,
+                    };
+                    if !cmp_kind_supported {
+                        return Err(QbeSmtError::Unsupported {
+                            message: format!("pc {pc}: unsupported compare operation"),
+                        });
+                    }
+                    if matches!(assign_ty, AssignType::Single | AssignType::Double)
+                        || matches!(cmp_assign_ty, AssignType::Double)
                     {
                         return Err(QbeSmtError::Unsupported {
                             message: format!("pc {pc}: unsupported compare operation"),
@@ -1510,8 +1557,10 @@ fn validate_statement_supported(
                 }
                 QbeInstr::Load(load_ty, ..) => {
                     let load_ty = load_store_type_from_qbe(load_ty);
-                    if matches!(assign_ty, AssignType::Single | AssignType::Double)
-                        || matches!(load_ty, LoadStoreType::Single | LoadStoreType::Double)
+                    if matches!(assign_ty, AssignType::Double)
+                        || matches!(load_ty, LoadStoreType::Double)
+                        || (matches!(assign_ty, AssignType::Single)
+                            != matches!(load_ty, LoadStoreType::Single))
                         || load_store_width_bits(load_ty).is_none()
                     {
                         return Err(QbeSmtError::Unsupported {
@@ -1572,7 +1621,7 @@ fn validate_statement_supported(
                     )?;
                 }
                 QbeInstr::Phi(label_left, _, label_right, _) => {
-                    if matches!(assign_ty, AssignType::Single | AssignType::Double) {
+                    if matches!(assign_ty, AssignType::Double) {
                         return Err(QbeSmtError::Unsupported {
                             message: format!(
                                 "pc {pc}: phi is unsupported for floating-point assignment type {:?}",
@@ -1603,7 +1652,7 @@ fn validate_statement_supported(
             QbeInstr::Store(store_ty, ..) => {
                 let store_ty = load_store_type_from_qbe(store_ty);
                 if load_store_width_bits(store_ty).is_none()
-                    || matches!(store_ty, LoadStoreType::Single | LoadStoreType::Double)
+                    || matches!(store_ty, LoadStoreType::Double)
                 {
                     return Err(QbeSmtError::Unsupported {
                         message: format!("pc {pc}: unsupported store operation"),
@@ -2531,31 +2580,58 @@ fn bounded_strcmp_result_expr(
 }
 
 fn binary_expr(instr: &QbeInstr, ty: AssignType, lhs: &str, rhs: &str) -> String {
-    let width = ty.bits();
+    match ty {
+        AssignType::Word | AssignType::Long => {
+            let width = ty.bits();
 
-    let expr_for_width = |lhs_expr: &str, rhs_expr: &str| match instr {
-        QbeInstr::Add(..) => format!("(bvadd {lhs_expr} {rhs_expr})"),
-        QbeInstr::Sub(..) => format!("(bvsub {lhs_expr} {rhs_expr})"),
-        QbeInstr::Mul(..) => format!("(bvmul {lhs_expr} {rhs_expr})"),
-        QbeInstr::Div(..) => format!("(bvsdiv {lhs_expr} {rhs_expr})"),
-        QbeInstr::Udiv(..) => format!("(bvudiv {lhs_expr} {rhs_expr})"),
-        QbeInstr::Rem(..) => format!("(bvsrem {lhs_expr} {rhs_expr})"),
-        QbeInstr::Urem(..) => format!("(bvurem {lhs_expr} {rhs_expr})"),
-        QbeInstr::And(..) => format!("(bvand {lhs_expr} {rhs_expr})"),
-        QbeInstr::Or(..) => format!("(bvor {lhs_expr} {rhs_expr})"),
-        QbeInstr::Shl(..) => format!("(bvshl {lhs_expr} {rhs_expr})"),
-        QbeInstr::Shr(..) => format!("(bvlshr {lhs_expr} {rhs_expr})"),
-        QbeInstr::Sar(..) => format!("(bvashr {lhs_expr} {rhs_expr})"),
-        _ => unreachable!("binary_expr called with non-binary instruction"),
-    };
+            let expr_for_width = |lhs_expr: &str, rhs_expr: &str| match instr {
+                QbeInstr::Add(..) => format!("(bvadd {lhs_expr} {rhs_expr})"),
+                QbeInstr::Sub(..) => format!("(bvsub {lhs_expr} {rhs_expr})"),
+                QbeInstr::Mul(..) => format!("(bvmul {lhs_expr} {rhs_expr})"),
+                QbeInstr::Div(..) => format!("(bvsdiv {lhs_expr} {rhs_expr})"),
+                QbeInstr::Udiv(..) => format!("(bvudiv {lhs_expr} {rhs_expr})"),
+                QbeInstr::Rem(..) => format!("(bvsrem {lhs_expr} {rhs_expr})"),
+                QbeInstr::Urem(..) => format!("(bvurem {lhs_expr} {rhs_expr})"),
+                QbeInstr::And(..) => format!("(bvand {lhs_expr} {rhs_expr})"),
+                QbeInstr::Or(..) => format!("(bvor {lhs_expr} {rhs_expr})"),
+                QbeInstr::Shl(..) => format!("(bvshl {lhs_expr} {rhs_expr})"),
+                QbeInstr::Shr(..) => format!("(bvlshr {lhs_expr} {rhs_expr})"),
+                QbeInstr::Sar(..) => format!("(bvashr {lhs_expr} {rhs_expr})"),
+                _ => unreachable!("binary_expr called with non-binary instruction"),
+            };
 
-    if width == 64 {
-        expr_for_width(lhs, rhs)
-    } else {
-        let lhs32 = extract_low_bits(lhs, 32);
-        let rhs32 = extract_low_bits(rhs, 32);
-        let expr32 = expr_for_width(&lhs32, &rhs32);
-        sign_extend_known_width(&expr32, 32, 64)
+            if width == 64 {
+                expr_for_width(lhs, rhs)
+            } else {
+                let lhs32 = extract_low_bits(lhs, 32);
+                let rhs32 = extract_low_bits(rhs, 32);
+                let expr32 = expr_for_width(&lhs32, &rhs32);
+                sign_extend_known_width(&expr32, 32, 64)
+            }
+        }
+        AssignType::Single => {
+            let lhs_fp = fp32_from_bv64(lhs);
+            let rhs_fp = fp32_from_bv64(rhs);
+            let fp_expr = match instr {
+                QbeInstr::Add(..) => {
+                    format!("(fp.add RNE {lhs_fp} {rhs_fp})")
+                }
+                QbeInstr::Sub(..) => {
+                    format!("(fp.sub RNE {lhs_fp} {rhs_fp})")
+                }
+                QbeInstr::Mul(..) => {
+                    format!("(fp.mul RNE {lhs_fp} {rhs_fp})")
+                }
+                QbeInstr::Div(..) => {
+                    format!("(fp.div RNE {lhs_fp} {rhs_fp})")
+                }
+                _ => unreachable!("unsupported FP32 binary instruction in binary_expr"),
+            };
+            fp32_to_bv64(&fp_expr)
+        }
+        AssignType::Double => {
+            unreachable!("FP64 assignments should be rejected")
+        }
     }
 }
 
@@ -2571,16 +2647,25 @@ fn cmp_to_smt(
     let lhs = value_to_smt(lhs, regs_curr, reg_slots, global_map);
     let rhs = value_to_smt(rhs, regs_curr, reg_slots, global_map);
 
-    if cmp_ty.bits() == 32 {
-        let lhs = extract_low_bits(&lhs, 32);
-        let rhs = extract_low_bits(&rhs, 32);
-        cmp_predicate(kind, &lhs, &rhs)
-    } else {
-        cmp_predicate(kind, &lhs, &rhs)
+    match cmp_ty {
+        AssignType::Word => {
+            let lhs = extract_low_bits(&lhs, 32);
+            let rhs = extract_low_bits(&rhs, 32);
+            cmp_predicate_int(kind, &lhs, &rhs)
+        }
+        AssignType::Long => cmp_predicate_int(kind, &lhs, &rhs),
+        AssignType::Single => {
+            let lhs_fp = fp32_from_bv64(&lhs);
+            let rhs_fp = fp32_from_bv64(&rhs);
+            cmp_predicate_fp32(kind, &lhs_fp, &rhs_fp)
+        }
+        AssignType::Double => {
+            unreachable!("FP64 compares should be rejected")
+        }
     }
 }
 
-fn cmp_predicate(kind: QbeCmp, lhs: &str, rhs: &str) -> String {
+fn cmp_predicate_int(kind: QbeCmp, lhs: &str, rhs: &str) -> String {
     match kind {
         QbeCmp::Eq => format!("(= {lhs} {rhs})"),
         QbeCmp::Ne => format!("(distinct {lhs} {rhs})"),
@@ -2595,7 +2680,28 @@ fn cmp_predicate(kind: QbeCmp, lhs: &str, rhs: &str) -> String {
         QbeCmp::Ule => format!("(bvule {lhs} {rhs})"),
         QbeCmp::Ugt => format!("(bvugt {lhs} {rhs})"),
         QbeCmp::Uge => format!("(bvuge {lhs} {rhs})"),
-        QbeCmp::O | QbeCmp::Uo => unreachable!("unsupported compares should be rejected"),
+        QbeCmp::O | QbeCmp::Uo => unreachable!("unsupported integer compares should be rejected"),
+    }
+}
+
+fn cmp_predicate_fp32(kind: QbeCmp, lhs: &str, rhs: &str) -> String {
+    match kind {
+        QbeCmp::Eq => format!("(fp.eq {lhs} {rhs})"),
+        QbeCmp::Ne => format!("(not (fp.eq {lhs} {rhs}))"),
+        QbeCmp::Lt => format!("(fp.lt {lhs} {rhs})"),
+        QbeCmp::Le => format!("(fp.leq {lhs} {rhs})"),
+        QbeCmp::Gt => format!("(fp.gt {lhs} {rhs})"),
+        QbeCmp::Ge => format!("(fp.geq {lhs} {rhs})"),
+        QbeCmp::O => format!("(and (not (fp.isNaN {lhs})) (not (fp.isNaN {rhs})))"),
+        QbeCmp::Uo => format!("(or (fp.isNaN {lhs}) (fp.isNaN {rhs}))"),
+        QbeCmp::Slt
+        | QbeCmp::Sle
+        | QbeCmp::Sgt
+        | QbeCmp::Sge
+        | QbeCmp::Ult
+        | QbeCmp::Ule
+        | QbeCmp::Ugt
+        | QbeCmp::Uge => unreachable!("unsupported FP32 compare kind"),
     }
 }
 
@@ -2663,7 +2769,8 @@ fn load_memory_expr(mem_expr: &str, address_expr: &str, load_ty: LoadStoreType) 
             zero_extend_known_width(&loaded, 16, 64)
         }
         LoadStoreType::Long => loaded,
-        LoadStoreType::Single | LoadStoreType::Double | LoadStoreType::Aggregate => {
+        LoadStoreType::Single => zero_extend_known_width(&loaded, 32, 64),
+        LoadStoreType::Double | LoadStoreType::Aggregate => {
             unreachable!("unsupported loads should be rejected")
         }
     }
@@ -2728,9 +2835,8 @@ fn normalize_to_assign_type(expr: &str, ty: AssignType) -> String {
     match ty {
         AssignType::Word => sign_extend_from_expr(expr, 32),
         AssignType::Long => expr.to_string(),
-        AssignType::Single | AssignType::Double => {
-            unreachable!("floating-point assignments should be rejected")
-        }
+        AssignType::Single => zero_extend_from_expr(expr, 32),
+        AssignType::Double => unreachable!("FP64 assignments should be rejected"),
     }
 }
 
@@ -2765,6 +2871,47 @@ fn zero_extend_known_width(expr: &str, from_bits: u32, to_bits: u32) -> String {
         expr.to_string()
     } else {
         format!("((_ zero_extend {}) {expr})", to_bits - from_bits)
+    }
+}
+
+fn fp32_from_bv64(expr: &str) -> String {
+    format!("((_ to_fp 8 24) {})", extract_low_bits(expr, 32))
+}
+
+fn fp32_to_bv64(expr: &str) -> String {
+    zero_extend_known_width(&format!("((_ fp.to_ieee_bv 8 24) {expr})"), 32, 64)
+}
+
+fn statement_uses_fp32(statement: &QbeStatement) -> bool {
+    let mut has_fp32 = false;
+    collect_values_in_statement(statement, &mut |value| {
+        if matches!(value, QbeValue::SingleConst(_)) {
+            has_fp32 = true;
+        }
+    });
+    if has_fp32 {
+        return true;
+    }
+
+    let instr = match statement {
+        QbeStatement::Assign(_, ty, instr) => {
+            if matches!(assign_type_from_qbe(ty), AssignType::Single) {
+                return true;
+            }
+            instr
+        }
+        QbeStatement::Volatile(instr) => instr,
+    };
+
+    match instr {
+        QbeInstr::Cmp(cmp_ty, _, _, _) => matches!(cmp_ty, QbeType::Single),
+        QbeInstr::Load(load_ty, _) => matches!(load_ty, QbeType::Single),
+        QbeInstr::Store(store_ty, _, _) => matches!(store_ty, QbeType::Single),
+        QbeInstr::Vaarg(va_ty, _) => matches!(va_ty, QbeType::Single),
+        QbeInstr::Call(_, args, _) => args.iter().any(|(arg_ty, arg_value)| {
+            matches!(arg_ty, QbeType::Single) || matches!(arg_value, QbeValue::SingleConst(_))
+        }),
+        _ => false,
     }
 }
 
@@ -2880,11 +3027,14 @@ fn value_to_smt(
             bv_const_u64(addr, 64)
         }
         QbeValue::Const(value) => bv_const_u64(*value, 64),
-        QbeValue::SingleConst(_) => {
-            unreachable!("floating-point constants should be rejected")
+        QbeValue::SingleConst(value) => {
+            let parsed = value
+                .parse::<f32>()
+                .unwrap_or_else(|_| panic!("invalid QBE FP32 literal: {value}"));
+            bv_const_u64(parsed.to_bits() as u64, 64)
         }
         QbeValue::DoubleConst(_) => {
-            unreachable!("floating-point constants should be rejected")
+            unreachable!("FP64 constants should be rejected")
         }
     }
 }

--- a/crates/qbe-smt/src/lib.rs
+++ b/crates/qbe-smt/src/lib.rs
@@ -1369,6 +1369,75 @@ mod tests {
     }
 
     #[test]
+    fn encodes_fp32_arithmetic_and_compares_with_all_logic() {
+        let function = make_main(
+            vec![(Type::Single, temp("a")), (Type::Single, temp("b"))],
+            vec![block(
+                "entry",
+                vec![
+                    assign("sum", Type::Single, Instr::Add(temp("a"), temp("b"))),
+                    assign(
+                        "is_lt",
+                        Type::Word,
+                        Instr::Cmp(Type::Single, Cmp::Lt, temp("sum"), temp("b")),
+                    ),
+                    volatile(Instr::Ret(Some(temp("is_lt")))),
+                ],
+            )],
+        );
+
+        let smt = encode_single_function(&function, &EncodeOptions::default())
+            .expect("FP32 arithmetic and compare should encode");
+
+        assert!(smt.contains("(set-logic ALL)"));
+        assert!(smt.contains("(fp.add RNE"));
+        assert!(smt.contains("(fp.lt"));
+    }
+
+    #[test]
+    fn encodes_fp32_loads_and_stores() {
+        let function = make_main(
+            vec![(Type::Long, temp("p")), (Type::Single, temp("x"))],
+            vec![block(
+                "entry",
+                vec![
+                    volatile(Instr::Store(Type::Single, temp("p"), temp("x"))),
+                    assign("loaded", Type::Single, Instr::Load(Type::Single, temp("p"))),
+                    assign(
+                        "eq",
+                        Type::Word,
+                        Instr::Cmp(Type::Single, Cmp::Eq, temp("loaded"), temp("x")),
+                    ),
+                    volatile(Instr::Ret(Some(temp("eq")))),
+                ],
+            )],
+        );
+
+        let smt = encode_single_function(&function, &EncodeOptions::default())
+            .expect("FP32 load/store should encode");
+        assert!(smt.contains("(set-logic ALL)"));
+        assert!(smt.contains("(store mem"));
+        assert!(smt.contains("(select mem"));
+    }
+
+    #[test]
+    fn rejects_fp64_function_arguments_fail_closed() {
+        let function = make_main(
+            vec![(Type::Double, temp("x"))],
+            vec![block(
+                "entry",
+                vec![volatile(Instr::Ret(Some(Value::Const(0))))],
+            )],
+        );
+
+        let err = encode_single_function(&function, &EncodeOptions::default())
+            .expect_err("FP64 arguments should remain unsupported");
+        assert!(err
+            .to_string()
+            .contains("unsupported floating-point function argument `%x`"));
+    }
+
+    #[test]
     fn encodes_phi_with_predecessor_guard() {
         let function = make_main(
             vec![(Type::Word, temp("cond"))],

--- a/crates/qbe-smt/src/lib.rs
+++ b/crates/qbe-smt/src/lib.rs
@@ -1421,20 +1421,75 @@ mod tests {
     }
 
     #[test]
-    fn rejects_fp64_function_arguments_fail_closed() {
+    fn encodes_fp64_arithmetic_and_compares_with_all_logic() {
+        let function = make_main(
+            vec![(Type::Double, temp("a")), (Type::Double, temp("b"))],
+            vec![block(
+                "entry",
+                vec![
+                    assign("sum", Type::Double, Instr::Add(temp("a"), temp("b"))),
+                    assign(
+                        "is_lt",
+                        Type::Word,
+                        Instr::Cmp(Type::Double, Cmp::Lt, temp("sum"), temp("b")),
+                    ),
+                    volatile(Instr::Ret(Some(temp("is_lt")))),
+                ],
+            )],
+        );
+
+        let smt = encode_single_function(&function, &EncodeOptions::default())
+            .expect("FP64 arithmetic and compare should encode");
+
+        assert!(smt.contains("(set-logic ALL)"));
+        assert!(smt.contains("(fp.add RNE"));
+        assert!(smt.contains("(fp.lt"));
+    }
+
+    #[test]
+    fn encodes_fp64_loads_and_stores() {
+        let function = make_main(
+            vec![(Type::Long, temp("p")), (Type::Double, temp("x"))],
+            vec![block(
+                "entry",
+                vec![
+                    volatile(Instr::Store(Type::Double, temp("p"), temp("x"))),
+                    assign("loaded", Type::Double, Instr::Load(Type::Double, temp("p"))),
+                    assign(
+                        "eq",
+                        Type::Word,
+                        Instr::Cmp(Type::Double, Cmp::Eq, temp("loaded"), temp("x")),
+                    ),
+                    volatile(Instr::Ret(Some(temp("eq")))),
+                ],
+            )],
+        );
+
+        let smt = encode_single_function(&function, &EncodeOptions::default())
+            .expect("FP64 load/store should encode");
+        assert!(smt.contains("(set-logic ALL)"));
+        assert!(smt.contains("(store mem"));
+        assert!(smt.contains("(select mem"));
+    }
+
+    #[test]
+    fn rejects_fp64_conversion_ops_fail_closed() {
         let function = make_main(
             vec![(Type::Double, temp("x"))],
             vec![block(
                 "entry",
-                vec![volatile(Instr::Ret(Some(Value::Const(0))))],
+                vec![
+                    assign("y", Type::Single, Instr::Truncd(temp("x"))),
+                    volatile(Instr::Ret(Some(temp("y")))),
+                ],
             )],
         );
 
         let err = encode_single_function(&function, &EncodeOptions::default())
-            .expect_err("FP64 arguments should remain unsupported");
+            .expect_err("FP64 conversion ops should remain unsupported");
         assert!(err
             .to_string()
-            .contains("unsupported floating-point function argument `%x`"));
+            .contains("unsupported unary operation truncd"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- extend `qbe-smt` encoding to detect FP32 usage, emit `ALL` logic, and model FP32 adds/comps/loads/stores while keeping FP64 fail-closed
- add FP32 proof and struct-invariant coverage plus qbe-smt/invariant docs updates and new execution fixtures/snapshots
- refresh AGENTS and pipeline/testing docs to reflect the FP32 support story and logic selection behavior

Testing:
- Not run (not requested)