### PR TITLE
Parallelize CI checks and run tests via nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
+      - run: cargo check --all-targets --all-features
+
+  nextest:
+    name: nextest
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
       - uses: goto-bus-stop/setup-zig@v2
         with:
@@ -32,5 +42,6 @@ jobs:
           sudo make -C /tmp/qbe-1.2 install
       - name: Install Rust
         run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
-      - run: cargo check --all-targets --all-features
-      - run: cargo test --all-targets --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --all-targets --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,8 @@ This repository contains the Ousia compiler workspace (`crates/*`) plus editor t
 - Execution fixture snapshots in `qbe_backend` are based on program stdout even when the process exits with a non-zero code; runtime errors are reserved for spawn failures, timeouts, invalid UTF-8, or signal termination.
 - `crates/oac/src/qbe_backend.rs` execution fixtures now compile/execute in parallel worker threads inside one test harness, but snapshot assertions stay deterministic by sorting fixture paths/results before asserting; worker count defaults to `min(available_parallelism, 8)` and can be overridden with `OAC_EXECUTION_TEST_JOBS=<n>`.
 - Snapshot hygiene is test-gated: committed `*.snap.new` files, execution snapshots without matching `execution_tests/*.oa` fixtures, and duplicated Ariadne prefixes (`Error: error[...]`) are treated as test failures.
-- GitHub Actions CI now provisions backend test/build dependencies before Rust checks (`z3`, Zig via `goto-bus-stop/setup-zig@v2` pinned to `0.13.0`, and `qbe` built from upstream `qbe-1.2` source tarball in `.github/workflows/ci.yml`).
+- GitHub Actions CI now runs Rust checks in parallel jobs in `.github/workflows/ci.yml`: `cargo check --all-targets --all-features` (`check`) and `cargo nextest run --all-targets --all-features` (`nextest`).
+- The `nextest` CI job provisions backend test/build dependencies (`z3`, Zig via `goto-bus-stop/setup-zig@v2` pinned to `0.13.0`, and `qbe` built from upstream `qbe-1.2` source tarball) and installs `cargo-nextest` via `taiki-e/install-action@nextest`.
 
 ## Hard-Cut Migration Cheatsheet
 

--- a/agents/01-repo-map.md
+++ b/agents/01-repo-map.md
@@ -50,7 +50,7 @@ Editor tooling in this repository:
 - `crates/oac/execution_tests/*.oa`: language behavior fixtures (positive + negative).
 - `crates/oac/bench/prove_baseline.json`: committed proving benchmark baseline used by `oac bench-prove`.
 - `crates/oac/src/snapshots/*.snap`: canonical snapshots for tests.
-- `.github/workflows/ci.yml`: CI checks (`cargo check`, `cargo test`).
+- `.github/workflows/ci.yml`: CI checks (`cargo check`, `cargo nextest`) in parallel jobs.
 - `.githooks/pre-commit`: local Git hook that formats staged Rust files with nightly `rustfmt`.
 - `.githooks/pre-push`: local Git hook placeholder (no automatic test execution).
 - `rustfmt.toml`: repository Rust formatting policy (nightly import-sorting behavior).

--- a/agents/04-testing-ci.md
+++ b/agents/04-testing-ci.md
@@ -3,12 +3,14 @@
 ## CI Contract
 
 Defined in `.github/workflows/ci.yml`:
-- `cargo check --all-targets --all-features`
-- `cargo test --all-targets --all-features`
-- backend dependency provisioning before Rust checks:
+- parallel Rust jobs:
+  - `check`: `cargo check --all-targets --all-features`
+  - `nextest`: `cargo nextest run --all-targets --all-features`
+- backend dependency provisioning in the `nextest` job:
   - `z3` (required for struct invariant/prove obligations)
   - `qbe` (required for backend assembly generation in execution-style tests; CI builds/installs upstream `qbe-1.2` from `https://c9x.me/compile/release/`)
   - Zig via `goto-bus-stop/setup-zig@v2` (pinned to `0.13.0`, used as `zig cc`)
+- `cargo-nextest` installation in CI via `taiki-e/install-action@nextest`
 
 Any change should keep both green.
 


### PR DESCRIPTION
- **Summary**
  - split `.github/workflows/ci.yml` into parallel `check` and `nextest` jobs so `cargo check` and `cargo nextest run` share infrastructure
  - install `cargo-nextest` in CI and document the updated workflow in `AGENTS.md`, `agents/01-repo-map.md`, and `agents/04-testing-ci.md`
- **Testing**
  - Not run (not requested)